### PR TITLE
Fix compile (for moarvm at least)

### DIFF
--- a/lib/DBDish/mysql.pm6
+++ b/lib/DBDish/mysql.pm6
@@ -33,7 +33,7 @@ sub mysql_fetch_field( OpaquePointer $result_set )
     { * }
 
 sub mysql_fetch_lengths( OpaquePointer $result_set )
-    returns CArray[Int]
+    returns CArray[int]
     is native('libmysqlclient')
     { * }
 


### PR DESCRIPTION
Rakudo on MoarVM was refusing to compile CArray[Int], as Int isn't a
native type.
