### PR TITLE
Pg config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ blib/
 minidbi-test.sqlite3
 *.moarvm
 *.jar
+*~

--- a/t/01-ConnectConfig-PG.t
+++ b/t/01-ConnectConfig-PG.t
@@ -1,0 +1,98 @@
+########################################################################
+# housekeeping
+########################################################################
+
+use v6;
+use Test;
+
+use lib 't/lib';
+use Test::Config::Pg;
+
+my @keyz    = < database user password host port >;
+my @varz    
+= map
+{
+    "PG{$_.uc}"
+},
+@keyz;
+
+dies-ok
+{
+    temp %*ENV< PGDATABASE > = '';
+    config_pg_connect;
+},
+"False PGDATABASE dies ({$!//''})";
+
+diag "Using PGDATABASE: %*ENV< PGDATABASE >";
+
+lives-ok
+{
+    temp %*ENV< PGDATABASE > = 'foobar';
+
+    given config_pg_connect() -> %optz 
+    {
+        ok %optz< database > eq %*ENV< PGDATABASE >, 
+        'database matches PGDATABASE';
+    }
+},
+"True PGDATABASE lives ({$!//''})";
+
+lives-ok
+{
+    temp %*ENV< PGDATABASE  > = 'foobar';
+    temp %*ENV< PGUSER      > = 'bletch';
+    temp %*ENV< PGPASSWORD  > = 'blort';
+    temp %*ENV< PGHOST      > = Nil;
+    temp %*ENV< PGPORT      > = Nil;
+
+    given config_pg_connect() -> %optz 
+    {
+        ok %optz< database  > eq %*ENV< PGDATABASE >, 
+        'database matches PGDATABASE';
+
+        ok %optz< user      > eq %*ENV< PGUSER     >, 
+        'user matches PGUSER';
+
+        ok %optz< password  > eq %*ENV< PGPASSWORD >, 
+        'password matches PGPASSWORD';
+
+        ok %optz< host      > eq 'localhost',
+        'host is localhost';
+
+        ok %optz< port      > eq '5432',
+        'port is 5432';
+    }
+},
+"True PGDATABASE lives ({$!//''})";
+
+lives-ok
+{
+    temp %*ENV< PGDATABASE  > = 'foobar';
+    temp %*ENV< PGUSER      > = 'bletch';
+    temp %*ENV< PGPASSWORD  > = 'blort';
+    temp %*ENV< PGHOST      > = 'bim';
+    temp %*ENV< PGPORT      > = 'bam';
+
+    given config_pg_connect() -> %optz 
+    {
+        ok %optz< database  > eq %*ENV< PGDATABASE  >, 
+        'database matches PGDATABASE';
+
+        ok %optz< user      > eq %*ENV< PGUSER      >, 
+        'user matches PGUSER';
+
+        ok %optz< password  > eq %*ENV< PGPASSWORD  >, 
+        'password matches PGPASSWORD';
+
+        ok %optz< host      > eq %*ENV< PGHOST      >, 
+        'host is localhost';
+
+        ok %optz< port      > eq %*ENV< PGPORT      >, 
+        'port is 5432';
+    }
+},
+"True PGDATABASE lives ({$!//''})";
+
+done
+
+=finish

--- a/t/30-Pg.t
+++ b/t/30-Pg.t
@@ -3,10 +3,16 @@ use Test;
 plan 2;
 use DBDish::Pg;
 
-is pg-replace-placeholder(q[INSERT INTO "foo?" VALUES('?', ?, ?)]),
-                          q[INSERT INTO "foo?" VALUES('?', $1, $2)],
-                         'basic tokenization';
+is pg-replace-placeholder\
+(
+    q[INSERT INTO "foo?" VALUES('?', ?, ?)]
+),
+q[INSERT INTO "foo?" VALUES('?', $1, $2)],
+'basic tokenization';
 
-is pg-replace-placeholder(q['a\.b''cd?', "\"?", ?]),
-                          q['a\.b''cd?', "\"?", $1],
-                        'backslash escapes and doubled single quote';
+is pg-replace-placeholder\
+(
+    q['a\.b''cd?', "\"?", ?]
+),
+q['a\.b''cd?', "\"?", $1],
+'backslash escapes and doubled single quote';

--- a/t/35-Pg-common.t
+++ b/t/35-Pg-common.t
@@ -3,41 +3,48 @@ use v6;
 use Test;
 use DBIish;
 
-# Define the only database specific values used by the common tests.
-my ( $*mdriver, %*opts ) = 'Pg';
-%*opts<host>     = 'localhost';
-%*opts<port>     = 5432;
-%*opts<database> = 'zavolaj';
-%*opts<user>     = 'testuser';
-%*opts<password> = 'testpass';
-my $dbh;
+use lib 't/lib';
+use Test::Config::Pg;
 
-my $post_connect_cb = {
+# Define the only database specific values used by the common tests.
+
+my $*mdriver    = 'Pg';
+my %*opts       = config_pg_connect;
+
+my $post_connect_cb =
+{
     my $dbh = @_.shift;
-    $dbh.do('SET client_min_messages = warning');
+
+    $dbh.do( 'SET client_min_messages = warning' );
 };
 
 # Detect and report possible errors from EVAL of the common test script
+
 warn $! if "ok 99-common.pl6" ne EVAL slurp 't/99-common.pl6';
 
 =begin pod
 
 =head1 PREREQUISITES
-Your system should already have libpq-dev installed.  Change to the
-postgres user and connect to the postgres server as follows:
 
- sudo -u postgres psql
+Your system should already have libpq-dev installed. 
 
-Then set up a test environment with the following:
+This uses the standard PG* environment variables to determine the 
+connection arguments:
 
- CREATE DATABASE zavolaj;
- CREATE ROLE testuser LOGIN PASSWORD 'testpass';
- GRANT ALL PRIVILEGES ON DATABASE zavolaj TO testuser;
+    export PGDATABASE = 'public';   # mininum required
 
-The '\l' psql command output should include zavolaj as a database name.
-Exit the psql client with a ^D, then try to use the new account:
+This will connect to the 'public' on 'localhost' at port 5432.
 
- psql --host=localhost --dbname=zavolaj --username=testuser --password
- SELECT * FROM pg_database;
+The user should have connect, create table priv's on the database.
+
+=head1 SEE ALSO
+
+=over 4
+
+=item t/lib/Test/Config/Pg.pm
+
+Env var's used to configure connection.
+
+=back
 
 =end pod

--- a/t/lib/Test/Config/Pg.pm
+++ b/t/lib/Test/Config/Pg.pm
@@ -1,0 +1,61 @@
+########################################################################
+# housekeeping
+# configure options for testing Postgres via DBIish::Pg
+########################################################################
+
+use v6;
+
+unit module Test::Config::Pg;
+
+sub config_pg_connect is export
+{
+    state %defaultz =
+    <
+        host    localhost
+        port    5432
+    >;
+
+    my %optz    = ();
+
+    %optz<database> = %*ENV< PGDATABASE >
+    or die 'Environment lacks PGDATABASE';
+
+    for < user password host port > -> $key
+    {
+        my $var         = %*ENV{ "PG{$key.uc}" } // %defaultz{ $key }
+        // next;
+
+        %optz{ $key }   = $var;
+    }
+
+    %optz
+}
+
+=begin pod
+
+=head1 NAME
+
+Test::Config::Pg - configuration for testing DBIish::Pg.
+
+=head1 SYNOPSIS
+
+    use Test::Config::Pg;
+
+    # checks for PGDATABASE in environment, returning false if
+    # it is not.
+    # 
+    # returns hash with kes of database, user password host port
+    # from defaults of PGDATABASE, PGUSER, PGPASSWORD, etc.
+    #
+    # defaults:
+    #   host => "localost"
+    #   port => "5432"
+    #
+    # lacking PGDATABASE raises an exception, other values 
+    # not avaiable in the environment are not returned.
+
+    my %test_connect_opts = config_pg_connect;
+
+=end pod
+
+=finish


### PR DESCRIPTION
Adds t/lib/Test/Config, initially with Pg, uses standard PG* env vars to configure the connection, saves user having to create hard-wired database and user/pass for the test; added test for env vars being used "t/01*t" and use module to set connection options; also added a bit of whitespace to t/30*t to make reading the start/end of test arg's easier. 

Currently working on config_mysql_connection to use MYSQL env var's for the connection.

Warn me if this seems reasonable.