### PR TITLE
added a fetchrow_typedhash method to have a hash value with correct p…

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -61,6 +61,9 @@ a subset of the functionality).
 It is based on Martin Berends' MiniDBI project, but unlike MiniDBI, DBDish
 aims to provide an interface that takes advantage of Perl 6 idioms
 
+Unlike perl5 DBI, it provide a fetchrow_typedhash method on DBD::StatementHandle
+that returns a hash with Perl6 typed value (work only with Pg for now)
+
 =head1 INSTALLATION
 
     $ panda install DBIish
@@ -68,7 +71,7 @@ aims to provide an interface that takes advantage of Perl 6 idioms
 =head1 DBDish CLASSES
 
 Until there is a benefit in doing it otherwise, the DBDish drivers stay
-and install together with the main DBIish.pm6 in a single project. 
+and install together with the main DBIish.pm6 in a single project.
 
 Currently the following backends are supported
 
@@ -78,7 +81,7 @@ Supports basic CRUD operations and prepared statements with placeholders
 
     my $dbh = DBIish.connect('Pg', :host<db01.yourdomain.com>, :port(5432),
             :database<blerg>, :user<myuser>, :$password);
-
+            
 =head2 SQLite
 
 Supports basic CRUD operations and prepared statements with placeholders

--- a/lib/DBDish.pm6
+++ b/lib/DBDish.pm6
@@ -59,6 +59,7 @@ role DBDish::StatementHandle does DBDish::ErrorHandling {
     }
 
     method fetchrow_hashref { $.fetchrow-hash }
+    method fetchrow_typedhash { die "Your selected backend does not support/implement typed values" }
 
     method fetchall-hash {
         my @names := self.column_names;


### PR DESCRIPTION
…erl6 type instead of all Str

Example:

```perl
use DBIish;
my $server = "localhost";
my $dbh = DBIish.connect("Pg", :host($server), :database<fimstat>, :user<fimstat>, :password<*****>, :RaiseError);

my $selectstory_req = $dbh.prepare("SELECT * from Story where id=?");

$selectstory_req.execute(230097);

my %story = $selectstory_req.fetchrow_typedhash();

say (%story<title>.perl, %story<views>.perl, %story<id>.perl, %story<prequel>.perl).join(";");
```
Display
"Crystal's Wishes";4520;230097;Bool::False

For me it allow to write stuff like this: (after parsing the pg_array)

```perl
my Story $story = Story.new(|%hash);
```

It's not documented because ... actually DBIish has not documentation so I did not really know how to put this.

