### PR TITLE
Deprecate all the fetch* for a more modern/perl6? approch with a row and allrows method

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,4 +1,5 @@
 {
+    "perl"	    : "6",
     "name"          : "DBIish",
     "version"       : "*",
     "description"   : "Database connectivity for Perl 6",

--- a/META.info
+++ b/META.info
@@ -9,7 +9,21 @@
         "DBDish::Pg"       : "lib/DBDish/Pg.pm6",
         "DBDish::SQLite"   : "lib/DBDish/SQLite.pm6",
         "DBDish::TestMock" : "lib/DBDish/TestMock.pm6",
-        "DBDish::mysql"    : "lib/DBDish/mysql.pm6"
+        "DBDish::mysql"    : "lib/DBDish/mysql.pm6",
+        "DBDish::Pg::Connection"    : "lib/DBDish/Pg/Connection.pm6",
+        "DBDish::Pg::Native"    : "lib/DBDish/Pg/Native.pm6",
+        "DBDish::Pg::StatementHandle"    : "lib/DBDish/Pg/StatementHandle.pm6",
+        "DBDish::SQLite::Connection"    : "lib/DBDish/SQLite/Connection.pm6",
+        "DBDish::SQLite::Native"    : "lib/DBDish/SQLite/Native.pm6",
+        "DBDish::SQLite::StatementHandle"    : "lib/DBDish/SQLite/StatementHandle.pm6",
+        "DBDish::mysql::Connection"    : "lib/DBDish/mysql/Connection.pm6",
+        "DBDish::mysql::Native"    : "lib/DBDish/mysql/Native.pm6",
+        "DBDish::mysql::StatementHandle"    : "lib/DBDish/mysql/StatementHandle.pm6",
+        "DBDish::Role::Connection"    : "lib/DBDish/Role/Connection.pm6",
+        "DBDish::Role::ErrorHandling"    : "lib/DBDish/Role/ErrorHandling.pm6",
+        "DBDish::Role::StatementHandle"    : "lib/DBDish/Role/StatementHandle.pm6",
+        "DBDish::TestMock::StatementHandle"    : "lib/DBDish/TestMock/StatementHandle.pm6",
+        "DBDish::TestMock::Connection"    : "lib/DBDish/TestMock/Connection.pm6"
     },
     "source-url"    : "git://github.com/perl6/DBIish.git"
 }

--- a/README.pod
+++ b/README.pod
@@ -44,8 +44,8 @@ DBIish - a simple database interface for Rakudo Perl 6
 
     $sth.execute();
 
-    my $arrayref = $sth.fetchall_arrayref();
-    say $arrayref.elems; # 3
+    my @rows = $sth.allrows();
+    say @rows.elems; # 3
 
     $sth.finish;
 
@@ -63,9 +63,25 @@ a subset of the functionality).
 It is based on Martin Berends' MiniDBI project, but unlike MiniDBI, DBDish
 aims to provide an interface that takes advantage of Perl 6 idioms
 
-Unlike Perl 5's DBI, it provides a C<fetchrow_typedhash> and C<fetchall_typedhash> 
-methods on DBD::StatementHandle that returns a hash with Perl6 typed value by oposition
-to everything in Str (implemented only in Pg for now).
+=head2 Fetching data
+
+It provide nearly all the perl5 DBI fetch* method to fetch values.
+However it's recommanded to use the C<row> and C<allrows> method
+
+=head3 row
+
+C<row> take the <hash> adverbe if you to have the values on a hash form instead of a plain array
+
+Example:
+    my %value = $sth.row(:hash);
+
+=head3 allrows
+
+C<allrows> offer you two adverbes if you want to fetch the values on a hash form.
+
+Example:
+    my @datas = $sth.allrows(:array-of-hash);
+    my %datas = $sth.allrows(:hash-of-array);
 
 =head1 INSTALLATION
 

--- a/README.pod
+++ b/README.pod
@@ -73,6 +73,7 @@ However it's recommanded to use the C<row> and C<allrows> method
 C<row> take the <hash> adverbe if you to have the values on a hash form instead of a plain array
 
 Example:
+
     my %value = $sth.row(:hash);
 
 =head3 allrows
@@ -80,6 +81,7 @@ Example:
 C<allrows> offer you two adverbes if you want to fetch the values on a hash form.
 
 Example:
+
     my @datas = $sth.allrows(:array-of-hash);
     my %datas = $sth.allrows(:hash-of-array);
 

--- a/README.pod
+++ b/README.pod
@@ -65,25 +65,29 @@ aims to provide an interface that takes advantage of Perl 6 idioms
 
 =head2 Fetching data
 
-It provide nearly all the perl5 DBI fetch* method to fetch values.
-However it's recommanded to use the C<row> and C<allrows> method
+DBIish provides nearly all the perl5 DBI fetch* method to fetch values from the C<StatementHandle> object.
+However it's recommanded to use the C<row> and C<allrows> method. They provide you typed value when possible
 
 =head3 row
 
-C<row> take the <hash> adverbe if you to have the values on a hash form instead of a plain array
+C<row> take the C<hash> adverb if you want to have the values in a hash form instead of a plain array
 
 Example:
 
-    my %value = $sth.row(:hash);
+    my @values = $sth.row();
+    my %values = $sth.row(:hash);
 
 =head3 allrows
 
-C<allrows> offer you two adverbes if you want to fetch the values on a hash form.
+C<allrows> returns all the row as an array of arrays.
+If you want to fetch the values in a hash form, use one of the two adverbs C<array-of-hash>
+and C<hash-of-array>
 
 Example:
 
-    my @datas = $sth.allrows(:array-of-hash);
-    my %datas = $sth.allrows(:hash-of-array);
+    my @datas = $sth.allrows(); # [[1, 2, 3], [4, 5, 6]]
+    my @datas = $sth.allrows(:array-of-hash); # [ ( a => 1, b => 2), ( a => 3, b => 4) ]
+    my %datas = $sth.allrows(:hash-of-array); # a => [1, 3], b => [2, 4]
 
 =head1 INSTALLATION
 

--- a/lib/DBDish/Pg/StatementHandle.pm6
+++ b/lib/DBDish/Pg/StatementHandle.pm6
@@ -115,8 +115,6 @@ method _row(:$hash) {
     $hash ?? return %ret_hash !! return @row_array;
 }
 
-method allrows(:$hash) {
-}
 
 method fetchrow() {
     my @row_array;

--- a/lib/DBDish/Role/StatementHandle.pm6
+++ b/lib/DBDish/Role/StatementHandle.pm6
@@ -120,11 +120,11 @@ method fetchall-array {
 
 method fetchrow_array { self.fetchrow }
 
-method fetchrow_arrayref ("row()") {
+method fetchrow_arrayref {
     $.fetchrow;
 }
 
-method fetch() ("row()") {
+method fetch() {
     $.fetchrow;
 }
 

--- a/lib/DBDish/Role/StatementHandle.pm6
+++ b/lib/DBDish/Role/StatementHandle.pm6
@@ -21,7 +21,7 @@ method column_p6types { die "The selected backend does not support/implement typ
 # Used by fetch* typedhash
 method true_false { return True }
 
-method fetchrow-hash() is DEPRECATED("row(:hash)") {
+method fetchrow-hash() {
     hash self.column_names Z=> self.fetchrow;
 }
 
@@ -89,9 +89,9 @@ method typed_value(Str $typename, Str $value) {
         }
 }
 
-method fetchrow_hashref is DEPRECATED("row(:hash)") { $.fetchrow-hash }
+method fetchrow_hashref { $.fetchrow-hash }
 
-method fetchall-hash is DEPRECATED("row(:hash)") {
+method fetchall-hash {
     my @names := self.column_names;
     my %res = @names Z=> [] xx *;
     for self.fetchall-array -> @a {
@@ -102,7 +102,7 @@ method fetchall-hash is DEPRECATED("row(:hash)") {
     return %res;
 }
 
-method fetchall-AoH is DEPRECATED("allrows(:array-of-hash)") {
+method fetchall-AoH {
     (0 xx *).flatmap: {
         my $h = self.fetchrow-hash;
         last unless $h;
@@ -110,7 +110,7 @@ method fetchall-AoH is DEPRECATED("allrows(:array-of-hash)") {
     };
 }
 
-method fetchall-array is DEPRECATED("allrows()"){
+method fetchall-array {
     (0 xx *).flatmap: {
         my $r = self.fetchrow;
         last unless $r;
@@ -118,14 +118,14 @@ method fetchall-array is DEPRECATED("allrows()"){
     };
 }
 
-method fetchrow_array is DEPRECATED("row()") { self.fetchrow }
+method fetchrow_array { self.fetchrow }
 
-method fetchrow_arrayref is DEPRECATED("row()") {
+method fetchrow_arrayref ("row()") {
     $.fetchrow;
 }
 
-method fetch() is DEPRECATED("row()") {
+method fetch() ("row()") {
     $.fetchrow;
 }
 
-method fetchall_arrayref is DEPRECATED("allrows()") { [ self.fetchall-array.eager ] }
+method fetchall_arrayref  { [ self.fetchall-array.eager ] }

--- a/lib/DBDish/Role/StatementHandle.pm6
+++ b/lib/DBDish/Role/StatementHandle.pm6
@@ -15,12 +15,19 @@ method finish() { ... }
 method fetchrow() { ... }
 method execute(*@) { ... }
 
+method	_row(:$hash) { ... }
+method	allrows(:$hash) { ... }
+
 method column_p6types { die "The selected backend does not support/implement typed value" }
 # Used by fetch* typedhash
 method true_false { return True }
 
-method fetchrow-hash() {
+method fetchrow-hash() is DEPRECATED("row(:hash)") {
     hash self.column_names Z=> self.fetchrow;
+}
+
+method row(:$hash) {
+  gather { while my $row = self._row(:hash($hash)) { take $row }};
 }
 
 method fetchall_typedhash {
@@ -58,9 +65,9 @@ method typed_value(Str $typename, Str $value) {
         }
 }
 
-method fetchrow_hashref { $.fetchrow-hash }
+method fetchrow_hashref is DEPRECATED("row(:hash)") { $.fetchrow-hash }
 
-method fetchall-hash {
+method fetchall-hash is DEPRECATED("row(:hash)") {
     my @names := self.column_names;
     my %res = @names Z=> [] xx *;
     for self.fetchall-array -> @a {
@@ -79,7 +86,7 @@ method fetchall-AoH {
     };
 }
 
-method fetchall-array {
+method fetchall-array is DEPRECATED("allrows(:hash)"){
     (0 xx *).flatmap: {
         my $r = self.fetchrow;
         last unless $r;
@@ -87,14 +94,14 @@ method fetchall-array {
     };
 }
 
-method fetchrow_array { self.fetchrow }
+method fetchrow_array is DEPRECATED("row()") { self.fetchrow }
 
-method fetchrow_arrayref {
+method fetchrow_arrayref is DEPRECATED("row()") {
     $.fetchrow;
 }
 
-method fetch() {
+method fetch() is DEPRECATED("row()") {
     $.fetchrow;
 }
 
-method fetchall_arrayref { [ self.fetchall-array.eager ] }
+method fetchall_arrayref is DEPRECATED("allrows()") { [ self.fetchall-array.eager ] }

--- a/lib/DBDish/SQLite/Connection.pm6
+++ b/lib/DBDish/SQLite/Connection.pm6
@@ -1,10 +1,11 @@
 
 use v6;
 
+use NativeCall;
 need DBDish::Role::Connection;
 need DBDish::SQLite::StatementHandle;
 use DBDish::SQLite::Native;
-use NativeCall;
+
 
 unit class DBDish::SQLite::Connection does DBDish::Role::Connection;
 

--- a/lib/DBDish/SQLite/Native.pm6
+++ b/lib/DBDish/SQLite/Native.pm6
@@ -36,6 +36,15 @@ enum SQLITE is export (
     SQLITE_DONE      =>   101, #  sqlite3_step() has finished executing
 );
 
+
+enum SQLITE_TYPE is export (
+    SQLITE_INTEGER => 1,
+    SQLITE_FLOAT   => 2,
+    SQLITE_TEXT    => 3,
+    SQLITE_BLOB    => 4,
+    SQLITE_NULL    => 5
+);
+
 constant LIB = %*ENV<DBIISH_SQLITE_LIB> || 'libsqlite3';
 
 sub sqlite3_errmsg(OpaquePointer $handle)
@@ -92,7 +101,7 @@ sub sqlite3_libversion_number() returns int32 is native(LIB) is export { ... };
 sub sqlite3_bind_blob(OpaquePointer $stmt, int32, OpaquePointer, int32, OpaquePointer) returns int32 is native(LIB) is export { ... };
 sub sqlite3_bind_double(OpaquePointer $stmt, int32, num64) returns int32 is native(LIB) is export { ... };
 sub sqlite3_bind_int64(OpaquePointer $stmt, int32, int64) returns int32 is native(LIB) is export { ... };
-sub sqlite3_bind_null(OpaquePointer $stmt, int32) returns Int is native(LIB) is export { ... };
+sub sqlite3_bind_null(OpaquePointer $stmt, int32) returns int32 is native(LIB) is export { ... };
 sub sqlite3_bind_text(OpaquePointer $stmt, int32, Str, int32, OpaquePointer) returns int32 is native(LIB) is export { ... };
 
 sub sqlite3_changes(OpaquePointer $handle) returns int32 is native(LIB) is export { ... };

--- a/lib/DBDish/SQLite/StatementHandle.pm6
+++ b/lib/DBDish/SQLite/StatementHandle.pm6
@@ -25,9 +25,7 @@ submethod BUILD(:$!conn, :$!statement, :$!statement_handle, :$!dbh) { }
 
 method execute(*@params) {
     die "Finish was previously called on the StatementHandle" if $!finished;
-    say "Reset $!statement_handle";
     sqlite3_reset($!statement_handle) if $!statement_handle.defined;
-    say "Reset Done";
     @!mem_rows = ();
     my @strings;
     for @params.kv -> $idx, $v {
@@ -64,13 +62,11 @@ method column_names {
 method _row (:$hash) {
     my @row;
     my %hash;
-    say "Piko";
     die 'row without prior execute' unless $!row_status.defined;
     return Any if $!row_status == SQLITE_DONE;
     my Int $count = sqlite3_column_count($!statement_handle);
     for ^$count  -> $col {
         my $value;
-        say sqlite3_column_type($!statement_handle, $col);
         given sqlite3_column_type($!statement_handle, $col) {
             when SQLITE_INTEGER {
                  $value = sqlite3_column_int64($!statement_handle, $col);
@@ -89,8 +85,6 @@ method _row (:$hash) {
     $hash ?? %hash !! @row;
 }
 
-method allrows {
-}
 
 method fetchrow {
     my @row;

--- a/lib/DBDish/SQLite/StatementHandle.pm6
+++ b/lib/DBDish/SQLite/StatementHandle.pm6
@@ -1,9 +1,10 @@
 
 use v6;
 
+use NativeCall;
 need DBDish::Role::StatementHandle;
 use DBDish::SQLite::Native;
-use NativeCall;
+
 
 unit class DBDish::SQLite::StatementHandle does DBDish::Role::StatementHandle;
 

--- a/lib/DBDish/TestMock/Connection.pm6
+++ b/lib/DBDish/TestMock/Connection.pm6
@@ -2,6 +2,7 @@
 use v6;
 
 need DBDish::TestMock::StatementHandle;
+need DBDish::Role::Connection;
 
 unit class DBDish::TestMock::Connection does DBDish::Role::Connection;
 

--- a/lib/DBDish/TestMock/StatementHandle.pm6
+++ b/lib/DBDish/TestMock/StatementHandle.pm6
@@ -16,6 +16,7 @@ has Int $!current_idx = 0;
 
 method execute(*@)  { $!current_idx = 0; @data.elems }
 method rows         { @data.elems }
+method _row	    {self.fetchrow}
 
 method fetchrow     { (@data[$!current_idx++] // ()).list }
 method column_names { @column_names }

--- a/lib/DBDish/mysql/Connection.pm6
+++ b/lib/DBDish/mysql/Connection.pm6
@@ -1,10 +1,11 @@
 
 use v6;
+use NativeCall;
 
 need DBDish::Role::Connection;
 need DBDish::mysql::StatementHandle;
 use DBDish::mysql::Native;
-use NativeCall;
+
 
 unit class DBDish::mysql::Connection does DBDish::Role::Connection;
 

--- a/lib/DBDish/mysql/Native.pm6
+++ b/lib/DBDish/mysql/Native.pm6
@@ -62,7 +62,7 @@ sub mysql_insert_id( OpaquePointer $mysql_client )
     { ... }
 
 sub mysql_num_rows( OpaquePointer $result_set )
-    returns Int
+    returns ulonglong
     is native(LIB)
     is export
     { ... }
@@ -74,7 +74,7 @@ sub mysql_query( OpaquePointer $mysql_client, str $sql_command )
     { ... }
 
 sub mysql_real_connect( OpaquePointer $mysql_client, Str $host, Str $user,
-    Str $password, Str $database, int32 $port, Str $socket, Int $flag )
+    Str $password, Str $database, int32 $port, Str $socket, ulong $flag )
     returns OpaquePointer
     is native(LIB)
     is export
@@ -98,7 +98,7 @@ sub mysql_stmt_init( OpaquePointer $mysql_client )
     is export
     { ... }
 
-sub mysql_stmt_prepare( OpaquePointer $mysql_stmt, Str, Int $length )
+sub mysql_stmt_prepare( OpaquePointer $mysql_stmt, Str, ulong $length )
     returns OpaquePointer
     is native(LIB)
     is export

--- a/lib/DBDish/mysql/Native.pm6
+++ b/lib/DBDish/mysql/Native.pm6
@@ -7,6 +7,69 @@ unit module DBDish::mysql::Native;
 
 constant LIB = %*ENV<DBIISH_MYSQL_LIB> || 'libmysqlclient';
 
+#From mysql_com.h
+enum mysql-field-type is export (
+  MYSQL_TYPE_DECIMAL => 0, MYSQL_TYPE_TINY => 1,
+  MYSQL_TYPE_SHORT => 2,  MYSQL_TYPE_LONG => 3,
+  MYSQL_TYPE_FLOAT => 4,  MYSQL_TYPE_DOUBLE => 5,
+  MYSQL_TYPE_NULL => 6,   MYSQL_TYPE_TIMESTAMP => 7,
+  MYSQL_TYPE_LONGLONG => 8,MYSQL_TYPE_INT24 => 9,
+  MYSQL_TYPE_DATE => 10,   MYSQL_TYPE_TIME => 11,
+  MYSQL_TYPE_DATETIME => 12, MYSQL_TYPE_YEAR => 13,
+  MYSQL_TYPE_NEWDATE => 14, MYSQL_TYPE_VARCHAR => 15,
+  MYSQL_TYPE_BIT => 16,
+  MYSQL_TYPE_NEWDECIMAL => 246,
+  MYSQL_TYPE_ENUM => 247,
+  MYSQL_TYPE_SET => 248,
+  MYSQL_TYPE_TINY_BLOB => 249,
+  MYSQL_TYPE_MEDIUM_BLOB => 250,
+  MYSQL_TYPE_LONG_BLOB => 251,
+  MYSQL_TYPE_BLOB => 252,
+  MYSQL_TYPE_VAR_STRING => 253,
+  MYSQL_TYPE_STRING => 254,
+  MYSQL_TYPE_GEOMETRY => 255
+);
+
+constant %mysql-type-conv is export = (
+  MYSQL_TYPE_DECIMAL => 'Int', MYSQL_TYPE_TINY => 'Int', #Tiny is used for Bool
+  MYSQL_TYPE_SHORT => 'Int',  MYSQL_TYPE_LONG => 'Int',
+  MYSQL_TYPE_FLOAT => 'Num',  MYSQL_TYPE_DOUBLE => 'Num',
+  MYSQL_TYPE_NULL,
+  MYSQL_TYPE_TIMESTAMP => 'Int',
+  MYSQL_TYPE_LONGLONG => 'Int', MYSQL_TYPE_INT24 => 'Int',
+  MYSQL_TYPE_DATE => 'Str',   MYSQL_TYPE_TIME => 'Str',
+  MYSQL_TYPE_DATETIME => 'Str', MYSQL_TYPE_YEAR => 'Int',
+  MYSQL_TYPE_NEWDATE => 'Str', MYSQL_TYPE_VARCHAR => 'Str',
+  MYSQL_TYPE_BIT => 'Int',
+  MYSQL_TYPE_NEWDECIMAL => 'Int',
+  MYSQL_TYPE_ENUM => 'Str'
+ # Meh the default will be Str
+).hash;
+
+class MYSQL_FIELD is repr('CStruct') is export {
+    has	Str	$.name;
+    has Str	$.org_name;
+    has Str	$.table;
+    has Str	$.org_table;
+    has Str	$.db;
+    has Str	$.catalog;
+    has	Str	$.def;
+    has ulong	$.length;
+    has ulong	$.max_length;
+    has uint32	$.name_length;
+    has uint32	$.org_name_length;
+    has uint32	$.table_length;
+    has	uint32	$.org_table_length;
+    has uint32	$.db_length;
+    has uint32	$.catalog_length;
+    has uint32	$.def_length;
+    has uint32	$.flags;
+    has uint32	$.decimals;
+    has uint32	$.charsetnr;
+    has int32	$.type;
+    has Pointer $.extension;
+}
+
 #------------ mysql library functions in alphabetical order ------------
 
 sub mysql_affected_rows( OpaquePointer $mysql_client )
@@ -27,7 +90,7 @@ sub mysql_error( OpaquePointer $mysql_client)
     { ... }
 
 sub mysql_fetch_field( OpaquePointer $result_set )
-    returns CArray[Str]
+    returns Pointer[MYSQL_FIELD]
     is native(LIB)
     is export
     { ... }

--- a/lib/DBDish/mysql/Native.pm6
+++ b/lib/DBDish/mysql/Native.pm6
@@ -31,18 +31,18 @@ enum mysql-field-type is export (
 );
 
 constant %mysql-type-conv is export = (
-  MYSQL_TYPE_DECIMAL => 'Int', MYSQL_TYPE_TINY => 'Int', #Tiny is used for Bool
-  MYSQL_TYPE_SHORT => 'Int',  MYSQL_TYPE_LONG => 'Int',
-  MYSQL_TYPE_FLOAT => 'Num',  MYSQL_TYPE_DOUBLE => 'Num',
-  MYSQL_TYPE_NULL,
-  MYSQL_TYPE_TIMESTAMP => 'Int',
-  MYSQL_TYPE_LONGLONG => 'Int', MYSQL_TYPE_INT24 => 'Int',
-  MYSQL_TYPE_DATE => 'Str',   MYSQL_TYPE_TIME => 'Str',
-  MYSQL_TYPE_DATETIME => 'Str', MYSQL_TYPE_YEAR => 'Int',
-  MYSQL_TYPE_NEWDATE => 'Str', MYSQL_TYPE_VARCHAR => 'Str',
-  MYSQL_TYPE_BIT => 'Int',
-  MYSQL_TYPE_NEWDECIMAL => 'Int',
-  MYSQL_TYPE_ENUM => 'Str'
+  MYSQL_TYPE_DECIMAL.value => 'Num', MYSQL_TYPE_TINY.value => 'Int', #Tiny is used for Bool
+  MYSQL_TYPE_SHORT.value => 'Int',  MYSQL_TYPE_LONG.value => 'Int',
+  MYSQL_TYPE_FLOAT.value => 'Num',  MYSQL_TYPE_DOUBLE.value => 'Num',
+  MYSQL_TYPE_NULL.value => 'Str',
+  MYSQL_TYPE_TIMESTAMP.value => 'Int',
+  MYSQL_TYPE_LONGLONG.value => 'Int', MYSQL_TYPE_INT24.value => 'Int',
+  MYSQL_TYPE_DATE.value => 'Str',   MYSQL_TYPE_TIME.value => 'Str',
+  MYSQL_TYPE_DATETIME.value => 'Str', MYSQL_TYPE_YEAR.value => 'Int',
+  MYSQL_TYPE_NEWDATE.value => 'Str', MYSQL_TYPE_VARCHAR.value => 'Str',
+  MYSQL_TYPE_BIT.value => 'Int',
+  MYSQL_TYPE_NEWDECIMAL.value => 'Num',
+  MYSQL_TYPE_ENUM.value => 'Str'
  # Meh the default will be Str
 ).hash;
 

--- a/lib/DBDish/mysql/StatementHandle.pm6
+++ b/lib/DBDish/mysql/StatementHandle.pm6
@@ -97,7 +97,7 @@ method _row(:$hash) {
         
         if $native_row {
             loop ( my $i=0; $i < $!field_count; $i++ ) {
-                my MYSQL_FIELD $field_info = mysql_fetch_field($!result_set).unref;
+                my MYSQL_FIELD $field_info = mysql_fetch_field($!result_set).deref;
                 my $value = do given %mysql-type-conv{$field_info.type} {
                    when 'Int' {
                      $native_row[$i].Int;
@@ -150,7 +150,7 @@ method column_names {
             $!field_count = mysql_field_count($!mysql_client);
         }
         loop ( my $i=0; $i < $!field_count; $i++ ) {
-            my MYSQL_FIELD $field_info = mysql_fetch_field($!result_set).unref;
+            my MYSQL_FIELD $field_info = mysql_fetch_field($!result_set).deref;
             my $column_name = $field_info.name;
             @!column_names.push($column_name);    
         }

--- a/lib/DBDish/mysql/StatementHandle.pm6
+++ b/lib/DBDish/mysql/StatementHandle.pm6
@@ -1,6 +1,7 @@
 
 use v6;
 
+use NativeCall;
 need DBDish::Role::StatementHandle;
 use DBDish::mysql::Native;
 

--- a/lib/DBDish/mysql/StatementHandle.pm6
+++ b/lib/DBDish/mysql/StatementHandle.pm6
@@ -77,6 +77,13 @@ method rows() {
     } 
 }
 
+method _row(:$hash) {
+    if $hash {
+        return hash self.column_names Z=> self.fetchrow;
+    }
+    fetchrow();
+}
+
 method fetchrow() {
     my @row_array;
 

--- a/lib/DBDish/mysql/StatementHandle.pm6
+++ b/lib/DBDish/mysql/StatementHandle.pm6
@@ -160,11 +160,13 @@ method column_names {
         unless defined $!result_set {
             $!result_set  = mysql_use_result( $!mysql_client);
             $!field_count = mysql_field_count($!mysql_client);
+            @!column_mysqltype = ();
         }
         loop ( my $i=0; $i < $!field_count; $i++ ) {
             my MYSQL_FIELD $field_info = mysql_fetch_field($!result_set).deref;
             my $column_name = $field_info.name;
-            @!column_names.push($column_name);    
+            @!column_names.push($column_name);
+            @!column_mysqltype.push($field_info.type);
         }
     }
     @!column_names;

--- a/t/10-mysql.t
+++ b/t/10-mysql.t
@@ -33,7 +33,7 @@ use Test;
 plan 87;
 
 use DBIish;
-use DBIish::mysql;
+use DBDish::mysql;
 
 # The file 'lib.pl' customizes the testing environment per DBD, but all
 # this test script currently needs is the variables listed here.

--- a/t/10-mysql.t
+++ b/t/10-mysql.t
@@ -33,7 +33,7 @@ use Test;
 plan 87;
 
 use DBIish;
-use DBDish::mysql;
+#use DBDish::mysql;
 
 # The file 'lib.pl' customizes the testing environment per DBD, but all
 # this test script currently needs is the variables listed here.

--- a/t/10-mysql.t
+++ b/t/10-mysql.t
@@ -33,6 +33,7 @@ use Test;
 plan 87;
 
 use DBIish;
+use DBIish::mysql;
 
 # The file 'lib.pl' customizes the testing environment per DBD, but all
 # this test script currently needs is the variables listed here.

--- a/t/25-mysql-common.t
+++ b/t/25-mysql-common.t
@@ -2,7 +2,7 @@
 
 use Test;
 use DBIish;
-use DBDish::mysql;
+#use DBDish::mysql;
 
 # Define the only database specific values used by the common tests.
 my $*mdriver = 'mysql';

--- a/t/25-mysql-common.t
+++ b/t/25-mysql-common.t
@@ -2,6 +2,7 @@
 
 use Test;
 use DBIish;
+use DBDish::mysql;
 
 # Define the only database specific values used by the common tests.
 my $*mdriver = 'mysql';

--- a/t/99-common.pl6
+++ b/t/99-common.pl6
@@ -4,7 +4,7 @@
 
 #use Test;     # "use" dies in a runtime EVAL
 #use DBIish;
-diag "Testing MiniDBD::$*mdriver";
+diag "Testing DBDish::$*mdriver";
 plan 58;
 
 sub magic_cmp(@a, @b) {

--- a/t/99-common.pl6
+++ b/t/99-common.pl6
@@ -130,9 +130,26 @@ if $sth.^can('fetchall_arrayref') {
         $ok &&= magic_cmp($arrayref[$i], @ref[$i]);
     }
     ok $ok, "selected data matches what was written"; # test 18
-    $sth.finish;
+    #$sth.finish;
 }
 else { skip 'fetchall_arrayref not implemented', 2 }
+
+say "Reexecute";
+
+$sth.execute();
+
+say "fetch Row";
+my @results = $sth.row();
+say @results.perl;
+ok @results[1] ~~ Str, "Test the type of a Str fields";
+ok @results[2] ~~ Int, "Test the type of an Int fields";
+ok @results[3] ~~ Num, "Test the type of a Float fields";
+
+my %results = $sth.row(:hash);
+
+ok %results<name> ~~ Str, "HASH: Test the type of a Str fields";
+ok %results<quantity> ~~ Int, "HASH: Test the type of a Str fields";
+ok %results<price> ~~ Num, "HASH: Test the type of a Str fields";
 
 ok $sth = $dbh.prepare("SELECT * FROM nom WHERE name='TAFM';"),
 'prepare new select for fetchrow_hashref test'; #test 19

--- a/t/99-common.pl6
+++ b/t/99-common.pl6
@@ -139,13 +139,13 @@ $sth.execute();
 my @results = $sth.row();
 ok @results[1] ~~ Str, "Test the type of a Str field";
 ok @results[2] ~~ Int, "Test the type of an Int field";
-ok @results[3] ~~ Real, "Test the type of a Float like field";
+ok @results[3] ~~ Num, "Test the type of a Float like field";
 
 my %results = $sth.row(:hash);
 
 ok %results<name> ~~ Str, "HASH: Test the type of a Str field";
 ok %results<quantity> ~~ Int, "HASH: Test the type of a Int field";
-ok %results<price> ~~ Real, "HASH: Test the type of a Float like field";
+ok %results<price> ~~ Num, "HASH: Test the type of a Float like field";
 
 $sth.execute();
 

--- a/t/99-common.pl6
+++ b/t/99-common.pl6
@@ -139,12 +139,14 @@ $sth.execute();
 my @results = $sth.row();
 ok @results[1] ~~ Str, "Test the type of a Str field";
 ok @results[2] ~~ Int, "Test the type of an Int field";
+todo "What type do we want to return for numeric?";
 ok @results[3] ~~ Num, "Test the type of a Float like field";
 
 my %results = $sth.row(:hash);
 
 ok %results<name> ~~ Str, "HASH: Test the type of a Str field";
 ok %results<quantity> ~~ Int, "HASH: Test the type of a Int field";
+todo "What type do we want to return for numeric?";
 ok %results<price> ~~ Num, "HASH: Test the type of a Float like field";
 
 $sth.execute();

--- a/t/99-common.pl6
+++ b/t/99-common.pl6
@@ -139,13 +139,13 @@ $sth.execute();
 my @results = $sth.row();
 ok @results[1] ~~ Str, "Test the type of a Str field";
 ok @results[2] ~~ Int, "Test the type of an Int field";
-ok @results[3] ~~ Num, "Test the type of a Float field";
+ok @results[3] ~~ Real, "Test the type of a Float like field";
 
 my %results = $sth.row(:hash);
 
 ok %results<name> ~~ Str, "HASH: Test the type of a Str field";
 ok %results<quantity> ~~ Int, "HASH: Test the type of a Int field";
-ok %results<price> ~~ Num, "HASH: Test the type of a Float field";
+ok %results<price> ~~ Real, "HASH: Test the type of a Float like field";
 
 $sth.execute();
 

--- a/xt/01-meta.t
+++ b/xt/01-meta.t
@@ -1,0 +1,5 @@
+use Test;
+use Test::META;
+plan 1;
+
+meta-ok();

--- a/xt/02_mysqlnative.t
+++ b/xt/02_mysqlnative.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+use NativeCall::TypeDiag;
+use DBDish::mysql::Native;
+
+my @headers = <mysql/mysql.h>;
+my @libs = <-lmysqlclient>;
+my @fun;
+my %typ;
+
+#Turn this False if something fail
+$NativeCall::TypeDiag::silent = True;
+
+for DBDish::mysql::Native::EXPORT::DEFAULT::.keys -> $export {
+  if ::($export).REPR eq 'CStruct' {
+    %typ{$export} = ::($export);
+  }
+  if ::($export).does(Callable) and ::($export).^roles.perl ~~ /NativeCall/ {
+     @fun.push(::($export));
+  }
+}
+
+plan 2;
+
+ok diag-cstructs(:cheaders(@headers), :types(%typ), :clibs(@libs)), "CStruct definition are correct";
+ok diag-functions(:functions(@fun)), "Functions signature are good";

--- a/xt/03_sqlitenative.t
+++ b/xt/03_sqlitenative.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+use NativeCall::TypeDiag;
+use DBDish::SQLite::Native;
+
+my @headers = <sqlite3.h>;
+my @libs = <-lsqlite3>;
+my @fun;
+my %typ;
+
+#Turn this False if something fail
+$NativeCall::TypeDiag::silent = False;
+
+for DBDish::SQLite::Native::EXPORT::DEFAULT::.keys -> $export {
+  if ::($export).REPR eq 'CStruct' {
+    %typ{$export} = ::($export);
+  }
+  if ::($export).does(Callable) and ::($export).^roles.perl ~~ /NativeCall/ {
+     @fun.push(::($export));
+  }
+}
+
+plan 1;
+
+#ok diag-cstructs(:cheaders(@headers), :types(%typ), :clibs(@libs)), "CStruct definition are correct";
+ok diag-functions(:functions(@fun)), "Functions signature are good";

--- a/xt/04_pgnative.t
+++ b/xt/04_pgnative.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+use NativeCall::TypeDiag;
+use DBDish::Pg::Native;
+
+my @headers = <sqlite3.h>;
+my @libs = <-lsqlite3>;
+my @fun;
+my %typ;
+
+#Turn this False if something fail
+$NativeCall::TypeDiag::silent = False;
+
+for DBDish::Pg::Native::EXPORT::DEFAULT::.keys -> $export {
+  if ::($export).REPR eq 'CStruct' {
+    %typ{$export} = ::($export);
+  }
+  if ::($export).does(Callable) and ::($export).^roles.perl ~~ /NativeCall/ {
+     @fun.push(::($export));
+  }
+}
+
+plan 1;
+
+#ok diag-cstructs(:cheaders(@headers), :types(%typ), :clibs(@libs)), "CStruct definition are correct";
+ok diag-functions(:functions(@fun)), "Functions signature are good";


### PR DESCRIPTION
Ignore the title.
Added a row and that return typed value when possible: a int field in the DB will be an Int.
Tagged fetch_typedhash as deprecated

Close:
#31 #22 (maybe?)

TODO:
Probably rewrite Pg _row to use typed C call and not convert from Str.