### PR TITLE
Fixed failed test 05-mock.t

### DIFF
--- a/lib/DBDish/TestMock/Connection.pm6
+++ b/lib/DBDish/TestMock/Connection.pm6
@@ -1,6 +1,7 @@
 
 use v6;
 
+use  DBDish::Role::Connection;
 need DBDish::TestMock::StatementHandle;
 
 unit class DBDish::TestMock::Connection does DBDish::Role::Connection;


### PR DESCRIPTION
In my environment, failed test 05-mock.t so fixed it.
```
$ perl6 -v
This is rakudo version 2015.11-313-g518b46f built on MoarVM version 2015.11-21-g469ba64 implementing Perl v6.b.
```
```
$ PERL6LIB=lib prove -e perl6 -vr t/05-mock.t                                                                                                 
t/05-mock.t ..
1..9
===SORRY!=== Error while compiling /Users/matsuohiroki/Github/DBIish/lib/DBDish/TestMock/Connection.pm6
Invalid typename 'DBDish::Role::Connection'
at /Users/matsuohiroki/Github/DBIish/lib/DBDish/TestMock/Connection.pm6:6
------> Connection does DBDish::Role::Connection
```