### PR TITLE
Typo in META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -18,7 +18,7 @@
         "DBDish::SQLite::StatementHandle"    : "lib/DBDish/SQLite/StatementHandle.pm6",
         "DBDish::mysql::Connection"    : "lib/DBDish/mysql/Connection.pm6",
         "DBDish::mysql::Native"    : "lib/DBDish/mysql/Native.pm6",
-        "DBDish::mysql::StatementHandle"    : "lib/mysql/SQLite/StatementHandle.pm6",
+        "DBDish::mysql::StatementHandle"    : "lib/DBDish/mysql/StatementHandle.pm6",
         "DBDish::Role::Connection"    : "lib/DBDish/Role/Connection.pm6",
         "DBDish::Role::ErrorHandling"    : "lib/DBDish/Role/ErrorHandling.pm6",
         "DBDish::Role::StatementHandle"    : "lib/DBDish/Role/StatementHandle.pm6",


### PR DESCRIPTION
It seems like the typo was made during copy-pasting.
(“DBDish/SQLite” was renamed to “mysql/SQLite” instead of “DBDish/mysql”)

Otherwise I get this error during the installation process:

> ==> Installing DBIish
> Failed to copy '/home/alex/.panda-work/1449289967_1/lib/mysql/SQLite/StatementHandle.pm6' to '/home/alex/.rakudobrew/moar-nom/install/share/perl6/site/sources/3F36563D9D917805E8100B616E6826BD973CC2D1': Failed to copy file: no such file or directory
