### PR TITLE
Added API version for sqlite/pg binding [Don't merge yet]

### DIFF
--- a/lib/DBDish/Pg/Native.pm6
+++ b/lib/DBDish/Pg/Native.pm6
@@ -5,7 +5,7 @@ use NativeCall;
 
 unit module DBDish::Pg::Native;
 
-constant LIB = %*ENV<DBIISH_PG_LIB> || 'libpq';
+constant LIB = %*ENV<DBIISH_PG_LIB> || ('libpq', 5);
 
 #------------ Pg library functions in alphabetical order ------------
 

--- a/lib/DBDish/Pg/Native.pm6
+++ b/lib/DBDish/Pg/Native.pm6
@@ -5,7 +5,7 @@ use NativeCall;
 
 unit module DBDish::Pg::Native;
 
-constant LIB = %*ENV<DBIISH_PG_LIB> || ('libpq', 5);
+constant LIB = %*ENV<DBIISH_PG_LIB> || ('pq', v5);
 
 #------------ Pg library functions in alphabetical order ------------
 

--- a/lib/DBDish/SQLite/Native.pm6
+++ b/lib/DBDish/SQLite/Native.pm6
@@ -45,7 +45,7 @@ enum SQLITE_TYPE is export (
     SQLITE_NULL    => 5
 );
 
-constant LIB = %*ENV<DBIISH_SQLITE_LIB> || 'libsqlite3';
+constant LIB = %*ENV<DBIISH_SQLITE_LIB> || ('libsqlite3' , 0);
 
 sub sqlite3_errmsg(OpaquePointer $handle)
     returns Str

--- a/lib/DBDish/SQLite/Native.pm6
+++ b/lib/DBDish/SQLite/Native.pm6
@@ -45,7 +45,7 @@ enum SQLITE_TYPE is export (
     SQLITE_NULL    => 5
 );
 
-constant LIB = %*ENV<DBIISH_SQLITE_LIB> || ('libsqlite3' , 0);
+constant LIB = %*ENV<DBIISH_SQLITE_LIB> || ('sqlite3', 0);
 
 sub sqlite3_errmsg(OpaquePointer $handle)
     returns Str

--- a/lib/DBDish/mysql/Native.pm6
+++ b/lib/DBDish/mysql/Native.pm6
@@ -5,7 +5,7 @@ use NativeCall;
 
 unit module DBDish::mysql::Native;
 
-constant LIB = %*ENV<DBIISH_MYSQL_LIB> || 'libmysqlclient';
+constant LIB = %*ENV<DBIISH_MYSQL_LIB> || 'mysqlclient';
 
 #From mysql_com.h
 enum mysql-field-type is export (


### PR DESCRIPTION
DON'T MERGE BEFORE X-MAS RELEASE. 
It's something that does not work on old NC version.


libmysqlclient follow a weird versioning pattern. it's 18 for me, So I left it like that.