### PR TITLE
GLRish for DBDish

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -6,5 +6,6 @@ The following people have contributed to DBIish (in alphabetical order):
 * Kaare Rasmussen
 * Martin Berends
 * Moritz Lenz
+* Salvador Ortiz
 * Susanne Schmidt
 * Tim Bunce

--- a/README.pod
+++ b/README.pod
@@ -9,7 +9,7 @@ DBIish - a simple database interface for Rakudo Perl 6
     use v6;
     use DBIish;
 
-    my $dbh = DBIish.connect("SQLite", :database<example-db.sqlite3>, :RaiseError);
+    my $dbh = DBIish.connect("SQLite", :database<example-db.sqlite3>);
 
     my $sth = $dbh.do(q:to/STATEMENT/);
         DROP TABLE IF EXISTS nom
@@ -66,11 +66,11 @@ aims to provide an interface that takes advantage of Perl 6 idioms
 =head2 Fetching data
 
 DBIish provides nearly all the perl5 DBI fetch* method to fetch values from the C<StatementHandle> object.
-However it's recommanded to use the C<row> and C<allrows> method. They provide you typed value when possible
+However it's recommanded to use the C<row> and C<allrows> methods. They provide you typed values
 
 =head3 row
 
-C<row> take the C<hash> adverb if you want to have the values in a hash form instead of a plain array
+C<row> take the C<hash> adverb if you want to have the values in a Hash form instead of a plain Array
 
 Example:
 
@@ -79,7 +79,7 @@ Example:
 
 =head3 allrows
 
-C<allrows> returns all the row as an array of arrays.
+C<allrows> lazily returns all the row as a list of arrays.
 If you want to fetch the values in a hash form, use one of the two adverbs C<array-of-hash>
 and C<hash-of-array>
 
@@ -95,10 +95,11 @@ Example:
 
 =head1 DBDish CLASSES
 
-Until there is a benefit in doing it otherwise, the DBDish drivers stay
-and install together with the main DBIish.pm6 in a single project.
+Some DBDish drivers install together with DBIish.pm6 and are maintained as a single project.
 
-Currently the following backends are supported
+Search the Perl 6 ecosystem for additional DBDish drivers.
+
+Currently the following backends are included:
 
 =head2 Pg (Postgresql)
 
@@ -110,7 +111,7 @@ Supports basic CRUD operations and prepared statements with placeholders
 Pg array are supported when fetching array fields with C<row/allrows>. You will
 get the properly typed array according to the field type.
 
-But passing array to C<execute/do> is not implemanted yet. You can use the
+But passing array to C<execute/do> is not implemented yet. You can use the
 C<pg-array-str> method on your Pg StatementHandle to convert an Array to a
 string Pg can understand.
 
@@ -136,20 +137,14 @@ and interpolating strings.
 
 =head1 TESTING
 
-The initial test script is merely a concatenation of all the scripts in
-the Perl 5 DBD::mysql test suite, translated to Perl 6.  It's not
-efficient but indispensable to assess coverage of the existing DBI
-feature set.  Only about 15% of the suite has been converted so far,
-with 86 tests passing, 0 todo and 0 skipped.
-
-The test suite will change to eliminate the current slowness and
-redundancy.  It will contain general tests as well as tests for
-particular databases.  The aim is to make the suite demonstrate portable
-and non portable operations.
+The DBIish::CommonTesting module, now with over 100 tests, provides a common unit
+testing that allows a driver developer to test its driver capabilities and the
+minimum expected compatibility.
 
 =head1 ROADMAP
 
-Add some more drivers. Improve robustness of all drivers. Improve the test suite.  Attract more contributors.
+Add some more drivers. Improve robustness of all drivers. Improve the test suite.
+Attract more contributors.
 
 Integrate with the DBDI project (L<http://github.com/timbunce/DBDI>)
 once it has sufficient functionality.

--- a/lib/DBDish/Pg/StatementHandle.pm6
+++ b/lib/DBDish/Pg/StatementHandle.pm6
@@ -27,18 +27,18 @@ submethod BUILD(:$!parent!, :$!pg_conn, # Per protocol
 
 method execute(*@params) {
     self!set-err( -1,
-	"Wrong number of arguments to method execute: got @params.elems(), expected @!param_type.elems()"
+        "Wrong number of arguments to method execute: got @params.elems(), expected @!param_type.elems()"
     ) if @params != @!param_type;
 
     self!enter-execute;
 
     my @param_values := ParamArray.new;
     for @params.kv -> $k, $v {
-	if $v.defined {
-	    @param_values[$k] = (@!param_type[$k] ~~ Buf)
-		?? $!pg_conn.escapeBytea(($v ~~ Buf) ?? $v !! ~$v.encode)
-		!! ~$v;
-	} else { @param_values[$k] = Str }
+        if $v.defined {
+            @param_values[$k] = (@!param_type[$k] ~~ Buf)
+                ?? $!pg_conn.escapeBytea(($v ~~ Buf) ?? $v !! ~$v.encode)
+                !! ~$v;
+        } else { @param_values[$k] = Str }
     }
 
     $!result = $!pg_conn.PQexecPrepared($!statement_name, @params.elems, @param_values,
@@ -50,21 +50,21 @@ method execute(*@params) {
 
     $!current_row = 0;
     with self!handle-errors {
-	my $rows; my $was-select = True;
+        my $rows; my $was-select = True;
         if $!result.PQresultStatus == PGRES_TUPLES_OK { # WAS SELECT
-	    without $!field_count {
-		$!field_count = $!result.PQnfields;
-		for ^$!field_count {
-		    @!column-name.push($!result.PQfname($_));
-		    @!column-type.push(%oid-to-type{$!result.PQftype($_)});
-		}
-	    }
+            without $!field_count {
+                $!field_count = $!result.PQnfields;
+                for ^$!field_count {
+                    @!column-name.push($!result.PQfname($_));
+                    @!column-type.push(%oid-to-type{$!result.PQftype($_)});
+                }
+            }
             $rows = $!row_count = $!result.PQntuples;
         } else { # Other stmt without data to return
-	    $rows =  $!result.PQcmdTuples.Int;
-	    $was-select = False;
+            $rows =  $!result.PQcmdTuples.Int;
+            $was-select = False;
         }
-	self!done-execute($rows, $was-select);
+        self!done-execute($rows, $was-select);
     } else {
         .fail;
     }
@@ -76,14 +76,14 @@ method _row() {
         $l = do for ^$!field_count {
             my $value = @!column-type[$_];
             unless $!result.PQgetisnull($!current_row, $_) {
-		$value = $!result.get-value($!current_row, $_, $value);
-		if @!column-type[$_] ~~ Array {
-		    $value = _pg-to-array($value, @!column-type[$_].of);
-		}
+                $value = $!result.get-value($!current_row, $_, $value);
+                if @!column-type[$_] ~~ Array {
+                    $value = _pg-to-array($value, @!column-type[$_].of);
+                }
             }
             $value;
     }
-	self.finish if ++$!current_row == $!row_count;
+        self.finish if ++$!current_row == $!row_count;
     }
     $l;
 }
@@ -115,18 +115,18 @@ sub _to-array(Match $match, Mu:U $type) {
     my $arr = Array[$type].new;
     my $clean = True;
     for $match.<array>.values -> $element {
-      if $element.values[0]<array>.defined { # An array
-	  if $clean && $arr.of === $type { # Need to downgrade
-	      $arr = Array.new; $clean = False;
-	  }
-          $arr.push: @(_to-array($element.values[0], $type));
-      } elsif $element.values[0]<float>.defined { # Floating point number
-          $arr.push: $type($element.values[0]<float>);
-      } elsif $element.values[0]<integer>.defined { # Integer
-          $arr.push: $type($element.values[0]<integer>);
-      } else { # Must be a String
-          $arr.push: ~$element.values[0]<string><value>;
-      }
+        if $element.values[0]<array>.defined { # An array
+            if $clean && $arr.of === $type { # Need to downgrade
+                $arr = Array.new; $clean = False;
+            }
+            $arr.push: @(_to-array($element.values[0], $type));
+        } elsif $element.values[0]<float>.defined { # Floating point number
+            $arr.push: $type($element.values[0]<float>);
+        } elsif $element.values[0]<integer>.defined { # Integer
+            $arr.push: $type($element.values[0]<integer>);
+        } else { # Must be a String
+            $arr.push: ~$element.values[0]<string><value>;
+        }
     }
     $arr;
 }
@@ -138,20 +138,20 @@ sub _pg-to-array(Str $text, Mu:U $type) {
 }
 
 method pg-array-str(@data) {
-  my @tmp;
-  for @data -> $c {
-    if  $c ~~ Array {
-      @tmp.push(self.pg-array-str($c));
-    } else {
-      if $c ~~ Numeric {
-        @tmp.push($c);
-      } else {
-         my $t = $c.subst('"', '\\"');
-         @tmp.push('"'~$t~'"');
-      }
+    my @tmp;
+    for @data -> $c {
+        if  $c ~~ Array {
+            @tmp.push(self.pg-array-str($c));
+        } else {
+            if $c ~~ Numeric {
+                @tmp.push($c);
+            } else {
+                my $t = $c.subst('"', '\\"');
+                @tmp.push('"'~$t~'"');
+            }
+        }
     }
-  }
-  '{' ~ @tmp.join(',') ~ '}';
+    '{' ~ @tmp.join(',') ~ '}';
 }
 
 method true_false(Str $s) {

--- a/lib/DBDish/StatementHandle.pm6
+++ b/lib/DBDish/StatementHandle.pm6
@@ -3,13 +3,19 @@ use v6;
 =begin pod
 =head2 role DBDish::StatementHandle
 The Connection C<prepare> method returns a StatementHandle object that
-mainly provides the C<execute> and C<finish> methods. It also has all the methods from C<DBDish::Role::ErrorHandling>.
+should provides the C<execute> and C<finish> methods.
+
+A Statetement handle should provide also the low-level C<_row> and C<_free>
+methods.
+
+It also has all the methods from C<DBDish::Role::ErrorHandling>.
 =end pod
 
 need DBDish::ErrorHandling;
 
 unit role DBDish::StatementHandle does DBDish::ErrorHandling;
 
+my role IntTrue { method Bool { self.defined } };
 
 has Int $.Executed = 0;
 has Bool $.Finished = True;
@@ -17,24 +23,22 @@ has Int $!affected_rows;
 has @!column-name;
 has @!column-type;
 
-method dispose() {
-    self.finish unless $!Finished;
-    self._free;
-    my \id := self.WHICH.Str;
-    ?($.parent.Statements{id}:delete);
-}
-#Avoid leaks if explicit dispose isn't used by the user.
-submethod DESTROY() {
-    self.dispose;
-}
+# My defined interface
+method execute(*@ --> IntTrue) { ... }
+method finish(--> Bool) { ... }
+method _row(--> Array) { ... }
+method _free() { ... }
+
 method !ftr() {
     $.parent.last-sth-id = self.WHICH;
 }
+
 method !enter-execute() {
     self.finish unless $!Finished;
     $!affected_rows = Nil;
     self!ftr;
 }
+
 method !done-execute(Int $rows, Bool $was-select) {
     $!Executed++;
     $!Finished = False;
@@ -48,20 +52,28 @@ method new(*%args) {
     %args<parent>.Statements{sth.WHICH} = sth;
 }
 
-my role IntTrue { method Bool { self.defined } };
+method dispose() {
+    self.finish unless $!Finished;
+    self._free;
+    my \id := self.WHICH.Str;
+    ?($.parent.Statements{id}:delete);
+}
+#Avoid leaks if explicit dispose isn't used by the user.
+submethod DESTROY() {
+    self.dispose;
+}
+
 method rows {
     $!affected_rows but IntTrue;
 }
 
-method _free() { ... }
-method finish(--> Bool) { ... }
-method fetchrow() { ... }
-method execute(*@ --> IntTrue) { ... }
-method	_row(:$hash) { ... }
-
 method row(:$hash) {
     self!ftr;
-    self._row(:$hash);
+    if my \r = self._row {
+	$hash ?? (@!column-name Z=> @(r)).hash !! r.Array;
+    } else {
+	$hash ?? % !! @;
+    }
 }
 
 method column-names {
@@ -73,18 +85,17 @@ method column-types {
 }
 
 multi method allrows(:$array-of-hash!) {
-    my @rows;
-    while self.row(:hash) -> %row {
-	@rows.push(%row);
+    gather {
+	while self.row(:hash) -> %r {
+	    take %r;
+	}
     }
-    @rows;
 }
 
 multi method allrows(:$hash-of-array!) {
-    my @names := @!column-name;
-    my %rows = @names Z=> [] xx *;
+    my %rows = @!column-name Z=> [] xx *;
     while self.row -> @a {
-	for @a Z @names -> ($v, $n) {
+	for @a Z @!column-name -> ($v, $n) {
 	    %rows{$n}.push: $v;
 	}
     }
@@ -92,18 +103,32 @@ multi method allrows(:$hash-of-array!) {
 }
 
 multi method allrows() {
-    my @rows;
-    while self.row -> @r {
-         @rows.push(@r);
+    gather {
+	while self.row -> @r {
+	    take @r;
+	}
     }
-    @rows;
 }
 
-method fetchrow-hash() {
+# Legacy
+method fetchrow {
+    if my \r = self._row {
+	my @ = (r.map: { .defined ?? ~$_ !! Str });
+    } else { @ };
+}
+
+method fetchrow-hash {
     hash @!column-name Z=> self.fetchrow;
 }
+method fetchrow_hashref { self.fetchrow-hash }
 
-method fetchrow_hashref { $.fetchrow-hash }
+method fetchall_hashref(Str $key) {
+    my %results;
+    while self.fetch-hash -> \h {
+	%results{h{$key}} = h;
+    }
+    %results;
+}
 
 method fetchall-hash {
     my @names := @!column-name;
@@ -113,7 +138,7 @@ method fetchall-hash {
             %res{$n}.push: $v;
         }
     }
-    return %res;
+    %res;
 }
 
 method fetchall-AoH {
@@ -133,13 +158,7 @@ method fetchall-array {
 }
 
 method fetchrow_array { self.fetchrow }
-
-method fetchrow_arrayref {
-    $.fetchrow;
-}
-
-method fetch() {
-    $.fetchrow;
-}
+method fetchrow_arrayref { self.fetchrow; }
+method fetch { self.fetchrow; }
 
 method fetchall_arrayref  { [ self.fetchall-array.eager ] }

--- a/lib/DBDish/TestMock/StatementHandle.pm6
+++ b/lib/DBDish/TestMock/StatementHandle.pm6
@@ -3,23 +3,18 @@ need DBDish;
 
 unit class DBDish::TestMock::StatementHandle does DBDish::StatementHandle;
 
-my @data = (
-       [<a b c>],
-       [<d e f>],
-);
+my @data = (|<a b>, 1), (|<d e>, 2);
 
 has Int $!current_idx = 0;
 
 method execute(*@)  {
     self!enter-execute;
     $!current_idx = 0;
-    @!column-name = <col1 col2 col3>;
+    @!column-name = <col1 col2 colN>;
+    @!column-type = (Str, Str, Int);
     self!done-execute(@data.elems, True)
 }
 
-method _row	    {self.fetchrow}
-
-method fetchrow     { (@data[$!current_idx++] // ()).list }
-
-method _free	    { }
-method finish       { True }
+method _row     { @data[$!current_idx++] // @ }
+method _free	{ }
+method finish   { True }

--- a/lib/DBIish.pm6
+++ b/lib/DBIish.pm6
@@ -1,7 +1,7 @@
 use v6;
 # DBIish.pm6
 
-unit class DBIish:auth<mberends>:ver<0.1.5>;
+unit class DBIish:auth<mberends>:ver<0.5.0>;
     use DBDish;
 
     package GLOBAL::X::DBIish {
@@ -47,8 +47,7 @@ unit class DBIish:auth<mberends>:ver<0.1.5>;
 	    };
 	}
 	my $d = self.install-driver( $driver );
-        my $connection = $d.connect(:$RaiseError, :$PrintError, :$AutoCommit, |%opts );
-        $connection;
+        $d.connect(:$RaiseError, :$PrintError, :$AutoCommit, |%opts );
     }
     method install-driver( $drivername ) {
 	my $d = %installed{$drivername} //= do {
@@ -153,7 +152,7 @@ our sub SQL_INTERVAL_MINUTE_TO_SECOND { 113 }
     use v6;
     use DBIish;
 
-    my $dbh = DBIish.connect("SQLite", :database<example-db.sqlite3>, :RaiseError);
+    my $dbh = DBIish.connect("SQLite", :database<example-db.sqlite3>);
 
     my $sth = $dbh.do(q:to/STATEMENT/);
         DROP TABLE nom

--- a/lib/DBIish/CommonTesting.pm6
+++ b/lib/DBIish/CommonTesting.pm6
@@ -332,7 +332,7 @@ method run-tests {
     if $sth.^can('fetchrow_arrayref') {
         ok my $arrayref = $sth.fetchrow_arrayref(), 'called fetchrow_arrayref'; #test 43
         is $arrayref.elems, 4, "fetchrow_arrayref returns 4 fields in a row"; #test 44
-        is $arrayref, [ 'PICO', 'Delish pina colada', '5', 7.90 ],
+        is $arrayref, [ 'PICO', 'Delish pina colada', '5', 7.9 ],
         'selected data matches test data of fetchrow_arrayref'; #test 45
     }
     else { skip 'fetchrow_arrayref not implemented', 2 }

--- a/lib/DBIish/CommonTesting.pm6
+++ b/lib/DBIish/CommonTesting.pm6
@@ -193,7 +193,7 @@ method run-tests {
     #fetch stuff return Str
     my @ref = [ Str, Str, "1", Str, Str],
         [ Str, Str, Str, "4.85", Str ],
-        [ 'BEOM', 'Medium size orange juice', "2", "1.20", "2.40" ],
+        [ 'BEOM', 'Medium size orange juice', "2", "1.2", "2.4" ],
         [ 'BUBH', 'Hot beef burrito', "1", "4.95", "4.95" ],
         [ 'ONE', Str, Str, Str, Str ],
         [ 'TAFM', 'Mild fish taco', "1", "4.85", "4.85" ];
@@ -207,7 +207,6 @@ method run-tests {
     for ^6 -> $i {
         $ok &&= @array[$i] eqv @ref[$i];
     }
-    todo "Will fail in sqlite, no real NUMERIC" if $.dbd eq 'SQLite';
     ok $ok, 'selected data be fetchall-array matches';
 
     # Re-execute the same statement
@@ -220,7 +219,7 @@ method run-tests {
 
     ok (@columns = $sth.column-types), 'called column-type';
     is @columns.elems, 5, "column-type returns 5 fields in a row";
-    ok @columns eqv ($.typed-nulls ?? 
+    ok @columns eqv ($.typed-nulls ??
 	[ Str, Str, Int, Rat, Rat ] !!
 	[ Any, Any, Any, Any, Any ]), 'column-types matches test data';
 
@@ -333,7 +332,7 @@ method run-tests {
     if $sth.^can('fetchrow_arrayref') {
         ok my $arrayref = $sth.fetchrow_arrayref(), 'called fetchrow_arrayref'; #test 43
         is $arrayref.elems, 4, "fetchrow_arrayref returns 4 fields in a row"; #test 44
-        ok self!magic-cmp($arrayref, [ 'PICO', 'Delish pina colada', '5', 7.90 ]),
+        is $arrayref, [ 'PICO', 'Delish pina colada', '5', 7.90 ],
         'selected data matches test data of fetchrow_arrayref'; #test 45
     }
     else { skip 'fetchrow_arrayref not implemented', 2 }

--- a/t/05-mock.t
+++ b/t/05-mock.t
@@ -1,31 +1,58 @@
 use v6;
 use Test;
 use DBIish;
-plan 9;
+plan 22;
 
 my $dbh = DBIish.connect('TestMock');
 my $sth = $dbh.prepare('everything');
 
 $sth.execute;
-is $sth.fetchrow.join(','), 'a,b,c', 'first row';
-is $sth.fetchrow.join(','), 'd,e,f', 'second row';
-nok $sth.fetchrow, 'third row is empty';
+is $sth.column-names, <col1 col2 colN>, 'Columns';
+is $sth.column-types.perl, [Str, Str, Int].perl,  'Types';
+is $sth.rows, 2, 'Results';
+
+is $sth.row.join(','), 'a,b,1', 'first row';
+is $sth.row.join(','), 'd,e,2', 'second row';
+nok $sth.row, 'third row is empty';
 
 $sth.execute;
-is-deeply [$sth.fetchall-array], [ [<a b c>], [<d e f>]], 'fetchall-array';
+is $sth.fetchrow.join(','), 'a,b,1', 'first row (legacy)';
+is $sth.fetchrow.join(','), 'd,e,2', 'second row (legacy)';
+nok $sth.fetchrow, 'third row is empty (legacy)';
 
 $sth.execute;
-is-deeply $sth.fetchrow-hash, hash(col1 => 'a', col2 => 'b', col3 => 'c'),
+# Testing the internals
+my \a = $sth.allrows;
+isa-ok a, Seq, 'allrows returns Seq';
+ok my $iter = a.iterator, 'Got iterator';
+is $iter.pull-one, ['a', 'b', 1], 'A row';
+
+$sth.execute;
+is-deeply [$sth.allrows], [ ['a', 'b', 1], ['d','e', 2]], 'allrows';
+$sth.execute;
+is-deeply [$sth.fetchall-array], [ ['a', 'b', '1'], ['d', 'e', '2']], 'fetchall-array';
+
+$sth.execute;
+is-deeply $sth.row :hash, hash(col1 => 'a', col2 => 'b', colN => 1),
+    'row :hash (1)';
+is-deeply $sth.row :hash, hash(col1 => 'd', col2 => 'e', colN => 2),
+    'row :hash (2)';
+is-deeply $sth.row :hash, hash(), 'row :hash (empty)';
+
+$sth.execute;
+is-deeply $sth.fetchrow-hash, hash(col1 => 'a', col2 => 'b', colN => '1'),
     'fetchrow-hash (1)';
-is-deeply $sth.fetchrow-hash, hash(col1 => 'd', col2 => 'e', col3 => 'f'),
+is-deeply $sth.fetchrow-hash, hash(col1 => 'd', col2 => 'e', colN => '2'),
     'fetchrow-hash (2)';
 is-deeply $sth.fetchrow-hash, hash(), 'fetchrow-hash (empty)';
 
 $sth.execute;
-is-deeply $sth.fetchall-hash, hash(col1 => [<a d>], col2 => [<b e>], col3 => [<c f>]), 'fetchall-HoA';
+is-deeply $sth.fetchall-hash, hash(
+    col1 => [<a d>], col2 => [<b e>], colN => ['1', '2']
+), 'fetchall-HoA';
 
 $sth.execute;
 is-deeply $sth.fetchall-AoH, (
-    {col1 => 'a', col2 => 'b', col3 => 'c'},
-    {col1 => 'd', col2 => 'e', col3 => 'f'},
+    {col1 => 'a', col2 => 'b', colN => '1'},
+    {col1 => 'd', col2 => 'e', colN => '2'},
 ).list, 'fetchall-AoH';


### PR DESCRIPTION
Row fetching is lazy so `.allrows()` and `.allrows(:array-of-hash)` methods now returns `Seq`

Named argument `:hash` of `.row` and  is now implemented by role, so drivers can be simplified.
Legacy `.fetchrow` is also implemented by role, so can be removed from drivers.
