### PR TITLE
Check for usage of in memory database

### DIFF
--- a/lib/DBDish/SQLite.pm6
+++ b/lib/DBDish/SQLite.pm6
@@ -10,7 +10,7 @@ method connect(:database(:$dbname)! is copy, :$RaiseError, *%params) {
 
     my SQLite $p .= new;
     # Add the standard extension unless has one
-    $dbname ~= '.sqlite3' unless $dbname ~~ / '.' /;
+    $dbname ~= '.sqlite3' unless $dbname ~~ / '.'|':memory:' /;
 
     my $status = sqlite3_open($dbname, $p);
     if $status == SQLITE_OK {


### PR DESCRIPTION
Currently when you try to create a database using :memory:, it creates the file :memory:.sqlite3.  But you can pass [:memory: to sqlite](https://www.sqlite.org/inmemorydb.html) to signify an in-memory database.