### PR TITLE
fixed t/10-mysql.t so it skips properly if mysqlclient not installed

### DIFF
--- a/t/10-mysql.t
+++ b/t/10-mysql.t
@@ -81,7 +81,7 @@ ok $drh_version ~~ Version:D, "DBDish::mysql version $drh_version"; # test 2
 my $dbh = try {
     CATCH { default {
         diag "Connect failed with error $_";
-        skip 'connect failed -- missing prereqs?', 85;
+        skip-rest 'prerequisites failed';
         exit;
 
     }}


### PR DESCRIPTION
This one-line change corrects an issue where if mysqlclient is not installed, not all tests in t/10-mysql.t get skipped.

<pre># Connect failed with error DBIish: DBDish::mysql needs 'mysqlclient', not found
# Looks like you planned 90 tests, but ran 87
t/10-mysql.t ..............
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 3/90 subtests
# DBIish: DBDish::mysql needs 'mysqlclient', not found
# Can't continue.
</pre>