### PR TITLE
sqlite: Use .dispose instead of .disconnect

### DIFF
--- a/examples/sqlite.p6
+++ b/examples/sqlite.p6
@@ -50,4 +50,4 @@ say $arrayref.elems; # 3
 
 # Cleanup
 $sth.finish;
-$dbh.disconnect;
+$dbh.dispose;


### PR DESCRIPTION
Fix #73