### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,6 +4,7 @@
     "version"       : "0.5.10",
     "description"   : "Database connectivity for Perl 6",
     "test-depends"  : [ ],
+    "license"       : "BSD-2-Clause",
     "depends" : [ "NativeHelpers::Blob" ],
     "provides" : {
         "DBIish"                    : "lib/DBIish.pm6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license