### PR TITLE
Fix infinite loops when passing certain arrays to pg-array-str

### DIFF
--- a/lib/DBDish/Pg/StatementHandle.pm6
+++ b/lib/DBDish/Pg/StatementHandle.pm6
@@ -151,7 +151,7 @@ sub _pg-to-array(Str $text, Mu:U $type) {
 
 method pg-array-str(\arr) {
     my @tmp;
-    my @data = arr ~~ Array ?? arr !! [ arr ];
+    my @data := arr ~~ Array ?? arr !! [ arr ];
     for @data -> $c {
         if $c ~~ Array {
             @tmp.push(self.pg-array-str($c));


### PR DESCRIPTION
Use binding (`my @arr := ...`) instead of assignment (`my @arr = ...`) to avoid creating additional arrays. This fixes two input types that give an infinite loop.

This fixes issue #107.