### PR TITLE
Remove unnecessary "is required" from several definitions.

### DIFF
--- a/lib/DBDish/Oracle/Connection.pm6
+++ b/lib/DBDish/Oracle/Connection.pm6
@@ -5,9 +5,9 @@ unit class DBDish::Oracle::Connection does DBDish::Connection;
 use DBDish::Oracle::Native;
 need DBDish::Oracle::StatementHandle;
 
-has OCIEnv    $!envh is required;
-has OCISvcCtx $!svch is required;
-has OCIError  $!errh is required;
+has OCIEnv    $!envh;
+has OCISvcCtx $!svch;
+has OCIError  $!errh;
 has $.AutoCommit is rw;
 has $.in_transaction is rw;
 submethod BUILD(:$!parent!, :$!envh, :$!svch, :$!errh, :$!AutoCommit = 1) { }

--- a/lib/DBDish/Oracle/StatementHandle.pm6
+++ b/lib/DBDish/Oracle/StatementHandle.pm6
@@ -5,9 +5,9 @@ unit class DBDish::Oracle::StatementHandle does DBDish::StatementHandle;
 use NativeHelpers::Blob;
 use DBDish::Oracle::Native;
 
-has OCISvcCtx $!svch is required;
-has OCIError  $!errh is required;
-has OCIStmt   $!stmth is required;
+has OCISvcCtx $!svch;
+has OCIError  $!errh;
+has OCIStmt   $!stmth;
 has $!statement;
 has $!stmttype;
 # For input parameters

--- a/lib/DBDish/Pg/Connection.pm6
+++ b/lib/DBDish/Pg/Connection.pm6
@@ -7,7 +7,7 @@ need DBDish::Pg::StatementHandle;
 need DBDish::TestMock;
 use DBIish::Common;
 
-has PGconn $!pg_conn is required handles <
+has PGconn $!pg_conn handles <
     pg-notifies pg-consume-input pg-socket pg-parameter-status
     pg-db pg-user pg-pass pg-host
     pg-port pg-options quote>;

--- a/lib/DBDish/SQLite/Connection.pm6
+++ b/lib/DBDish/SQLite/Connection.pm6
@@ -6,7 +6,7 @@ unit class DBDish::SQLite::Connection does DBDish::Connection;
 need DBDish::SQLite::StatementHandle;
 use DBDish::SQLite::Native;
 
-has SQLite $!conn is required;
+has SQLite $!conn;
 
 submethod BUILD(:$!conn, :$!parent!) { }
 

--- a/lib/DBDish/mysql/Connection.pm6
+++ b/lib/DBDish/mysql/Connection.pm6
@@ -6,7 +6,7 @@ unit class DBDish::mysql::Connection does DBDish::Connection;
 use DBDish::mysql::Native;
 need DBDish::mysql::StatementHandle;
 
-has MYSQL $!mysql_client is required;
+has MYSQL $!mysql_client;
 
 submethod BUILD(:$!mysql_client, :$!parent!) { }
 

--- a/lib/DBDish/mysql/StatementHandle.pm6
+++ b/lib/DBDish/mysql/StatementHandle.pm6
@@ -6,7 +6,7 @@ use DBDish::mysql::Native;
 use NativeHelpers::Blob;
 use NativeHelpers::CStruct;
 
-has MYSQL $!mysql_client is required;
+has MYSQL $!mysql_client;
 has MYSQL_STMT $!stmt;
 has int $!param-count;
 has $!statement;


### PR DESCRIPTION
This was causing problems with current rakudo HEAD which disallows
such a condition on private attributes.