### PR TITLE
Add code to fail with explicit error messages when required attribute…

### DIFF
--- a/lib/DBDish/Oracle/Connection.pm6
+++ b/lib/DBDish/Oracle/Connection.pm6
@@ -10,7 +10,11 @@ has OCISvcCtx $!svch;
 has OCIError  $!errh;
 has $.AutoCommit is rw;
 has $.in_transaction is rw;
-submethod BUILD(:$!parent!, :$!envh, :$!svch, :$!errh, :$!AutoCommit = 1) { }
+submethod BUILD(:$!parent!,
+                :$!envh = die ("Required attribute 'envh' missing for new DBDish::Oracle::Connection"),
+                :$!svch = die ("Required attribute 'svch' missing for new DBDish::Oracle::Connection"),
+                :$!errh = die ("Required attribute 'errh' missing for new DBDish::Oracle::Connection"),
+                :$!AutoCommit = 1) { }
 
 method !handle-err($res) {
     $res ~~ OCIErr ?? self!set-err(+$res, ~$res) !! $res;

--- a/lib/DBDish/Oracle/StatementHandle.pm6
+++ b/lib/DBDish/Oracle/StatementHandle.pm6
@@ -26,7 +26,9 @@ method !handle-err($res) {
 }
 
 submethod BUILD(:$!parent!, :$!statement!, :$!RaiseError,
-    :$!svch, :$!errh, :$!stmth,
+    :$!svch  = die ("Required attribute 'svch' missing for new DBDish::Oracle::StatementHandle"),
+    :$!errh  = die ("Required attribute 'errh' missing for new DBDish::Oracle::StatementHandle"),
+    :$!stmth = die ("Required attribute 'stmth' missing for new DBDish::Oracle::StatementHandle"),
 ) {
     $!stmttype = $!stmth.AttrGet($!errh, ub2, OCI_ATTR_STMT_TYPE);
     if $!param-count = $!stmth.AttrGet($!errh, ub4, OCI_ATTR_BIND_COUNT) -> $pn {

--- a/lib/DBDish/Pg/Connection.pm6
+++ b/lib/DBDish/Pg/Connection.pm6
@@ -16,7 +16,9 @@ has $.in_transaction is rw = False;
 has %.Converter is DBDish::TypeConverter;
 has %.dynamic-types = %oid-to-type;
 
-submethod BUILD(:$!pg_conn, :$!parent!, :$!AutoCommit) {
+submethod BUILD(:$!pg_conn = die("Required attribute 'pg_conn' missing for new DBD::Pg::Connection"),
+                :$!parent  = die("Required attribute 'pg_conn' missing for new DBD::Pg::Connection"),
+                :$!AutoCommit) {
     %!Converter =
        method (--> Bool) { self eq 't' },
        method (--> DateTime) { DateTime.new(self.split(' ').join('T')) },

--- a/lib/DBDish/Pg/StatementHandle.pm6
+++ b/lib/DBDish/Pg/StatementHandle.pm6
@@ -36,8 +36,10 @@ submethod !get-meta($result) {
     }
 }
 
-submethod BUILD(:$!parent!, :$!pg_conn, # Per protocol
-    :$!statement, :$!statement_name = ''
+submethod BUILD(:$!parent = die ("Required attribute 'parent' missing for new DBDish::Pg::StatementHandle", 
+                :$!pg_conn,  # Per protocol
+                :$!statement,
+                :$!statement_name = ''
 ) {
     if $!statement_name { # Prepared
         with $!pg_conn.PQdescribePrepared($!statement_name) -> $info {

--- a/lib/DBDish/SQLite/Connection.pm6
+++ b/lib/DBDish/SQLite/Connection.pm6
@@ -8,7 +8,9 @@ use DBDish::SQLite::Native;
 
 has SQLite $!conn;
 
-submethod BUILD(:$!conn, :$!parent!) { }
+submethod BUILD(:$!conn   = die ("Required attribute 'conn' missing for new DBDish::SQLite::Conection"),
+                :$!parent = die ("Required attribute 'parent' missing for new DBDish::SQLite::Conection")
+               ) { }
 
 method !handle-error(Int $status) {
     if $status == SQLITE_OK {

--- a/lib/DBDish/SQLite/StatementHandle.pm6
+++ b/lib/DBDish/SQLite/StatementHandle.pm6
@@ -21,8 +21,11 @@ method !handle-error($status) {
     }
 }
 
-submethod BUILD(:$!conn!, :$!parent!,
-    :$!statement_handle!, :$!statement, :$!param-count
+submethod BUILD(:$!conn             = die "Required attribute 'conn' missing for new DBDish::SQLite::StatementHandle"),
+                :$!parent           = die "Required attribute 'parent' missing for new DBDish::SQLite::StatementHandle"),
+                :$!statement_handle = die "Required attribute 'statement_handle' missing for new DBDish::SQLite::StatementHandle"),
+                :$!statement,
+                :$!param-count
 ) {
     $!field_count = sqlite3_column_count($!statement_handle);
     for ^$!field_count {

--- a/lib/DBDish/mysql/Connection.pm6
+++ b/lib/DBDish/mysql/Connection.pm6
@@ -8,7 +8,8 @@ need DBDish::mysql::StatementHandle;
 
 has MYSQL $!mysql_client;
 
-submethod BUILD(:$!mysql_client, :$!parent!) { }
+submethod BUILD(:$!mysql_client = die ("Required attribute 'mysql_client' missing for new DBDish::mysql::Connection"),
+                :$!parent       = die ("Required attribute 'parent' missing for new DBDish::mysql::Connection")) { }
 
 method !handle-errors($code) {
     if $code {
@@ -16,6 +17,7 @@ method !handle-errors($code) {
     } else {
     self.reset-err;
     }
+ $_
 }
 method prepare(Str $statement, *%args) {
     with $!mysql_client.mysql_stmt_init -> $stmt {

--- a/lib/DBDish/mysql/StatementHandle.pm6
+++ b/lib/DBDish/mysql/StatementHandle.pm6
@@ -48,7 +48,8 @@ method !get-meta(MYSQL_RES $res) {
     $lengths;
 }
 
-submethod BUILD(:$!mysql_client!, :$!parent!, :$!stmt = MYSQL_STMT,
+submethod BUILD(:$!mysql_client = die ("Required attribute 'mysql_client' missing for new DBDish::mysql::StatementHandle"),
+                :$!parent = die ("Required attribute 'parent' missing for new DBDish::mysql::StatementHandle"), :$!stmt = MYSQL_STMT,
     :$!statement, Bool :$!Prefetch = True
 ) {
     with $!stmt { #Prepared


### PR DESCRIPTION
…s are missing for new

connections and statement handles.

These are probably never used by end users, but explicit messages never hurt.