### PR TITLE
Get multi-threaded use of SQLite working

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -201,10 +201,33 @@ Supports basic CRUD operations and prepared statements with placeholders
 
     my $dbh = DBIish.connect('SQLite', :database<thefile>);
     
-The :database parameter can be an absolute file path as well:
+The C<:database> parameter can be an absolute file path as well (or even an
+C<IO::Path> object):
 
     my $dbh = DBIish.connect('SQLite', database => '/path/to/sqlite.db' );
-    
+
+If the SQLite library was compiled to be threadsafe (which is usually the
+case), then it is possible to use SQLite from multiple threads. This can be
+introspected:
+
+    say DBIish.install-driver('SQLite').threadsafe;
+
+SQLite does support using one connection object concurrently, however other
+databases may not; if portability is a concern, then only use a particular
+connection object from one thread at a time (and so have multiple connection
+objects).
+
+When using a SQLite database concurrently (from multiple threads, or even
+multiple processes), operations may not be able to happen immediately due to
+the database being locked. DBIish sets a default timeout of 10000 miliseconds;
+this can be changed by passing the C<busy-timeout> option to C<connect>.
+
+    my $dbh = DBIish.connect('SQLite', :database<thefile>, :60000busy-timeout);
+
+Passing a value less than or equal to zero will disable the timeout, resulting
+in any operation that cannot take place immediately producing a database
+locked error.
+
 =head2 mysql
 
 Supports basic CRUD operations and prepared statements with placeholders

--- a/lib/DBDish/Connection.pm6
+++ b/lib/DBDish/Connection.pm6
@@ -28,7 +28,7 @@ method dispose() {
         %!statements = ();
     }
     self._disconnect;
-    ?($.parent.Connections{self.WHICH}:delete);
+    ?($.parent.unregister-connection(self))
 }
 submethod DESTROY() {
     self.dispose;
@@ -44,7 +44,7 @@ method new(*%args) {
     my \con = ::?CLASS.bless(|%args);
     con.reset-err;
     con.?set-defaults;
-    %args<parent>.Connections{con.WHICH} = con;
+    %args<parent>.register-connection(con)
 }
 
 method prepare(Str $statement, *%args) { ... }

--- a/lib/DBDish/SQLite.pm6
+++ b/lib/DBDish/SQLite.pm6
@@ -21,6 +21,9 @@ method connect(Str() :database(:$dbname)! is copy, *%params) {
 
     my $status = sqlite3_open($dbname, $p);
     if $status == SQLITE_OK {
+        given %params<busy-timeout> // 10000 {
+            sqlite3_busy_timeout($p, .Int);
+        }
         DBDish::SQLite::Connection.new(:conn($p), :parent(self), |%params);
     }
     else {

--- a/lib/DBDish/SQLite.pm6
+++ b/lib/DBDish/SQLite.pm6
@@ -10,7 +10,7 @@ need DBDish::SQLite::Connection;
 has $.library;
 has $.library-resolved = False;
 
-method connect(:database(:$dbname)! is copy, *%params) {
+method connect(Str() :database(:$dbname)! is copy, *%params) {
     die "Cannot locate native library '" ~
     $*VM.platform-library-name('sqlite3'.IO, :version(v0)) ~ "'"
     unless $!library-resolved;

--- a/lib/DBDish/SQLite.pm6
+++ b/lib/DBDish/SQLite.pm6
@@ -46,4 +46,8 @@ method version() {
     $!library-resolved ?? Version.new(sqlite3_libversion) !! Nil;
 }
 
+method threadsafe(--> Bool) {
+    so sqlite3_threadsafe()
+}
+
 # vim: ft=perl6

--- a/lib/DBDish/SQLite/Native.pm6
+++ b/lib/DBDish/SQLite/Native.pm6
@@ -75,6 +75,11 @@ sub sqlite3_close(SQLite)
     is export
     { ... }
 
+sub sqlite3_busy_timeout(SQLite, int32)
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
 
 sub sqlite3_prepare_v2 (
         SQLite,

--- a/lib/DBDish/SQLite/Native.pm6
+++ b/lib/DBDish/SQLite/Native.pm6
@@ -57,6 +57,12 @@ class STMT is export is repr('CPointer') { };
 # at install time.
 #constant SQLITE_TRANSIENT = Pointer.new(-1);
 
+sub sqlite3_threadsafe()
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
+
 sub sqlite3_errmsg(SQLite $handle)
     returns Str
     is native(LIB)

--- a/lib/DBDish/StatementHandle.pm6
+++ b/lib/DBDish/StatementHandle.pm6
@@ -52,13 +52,13 @@ method !done-execute(Int $rows, $fields) {
 
 method new(*%args) {
     my \sth = ::?CLASS.bless(|%args);
-    %args<parent>.Statements{sth.WHICH} = sth;
+    %args<parent>.register-statement-handle(sth)
 }
 
 method dispose() {
     self.finish unless $!Finished;
     self._free;
-    with $.parent.Statements{self.WHICH}:delete {
+    with $.parent.unregister-statement-handle(self) {
         $.parent.last-rows = self.rows;
         True;
     } else { False };

--- a/lib/DBDish/mysql/Connection.pm6
+++ b/lib/DBDish/mysql/Connection.pm6
@@ -39,8 +39,8 @@ method execute(Str $statement, *%args) {
 }
 
 method insert-id() {
-    with $!last-sth-id andthen %!Statements{$_} {
-    .insert-id;
+    with $!last-sth-id andthen $!statements-lock.protect({ %!statements{$_} }) {
+        .insert-id;
     }
 }
 

--- a/t/43-sqlite-threads.t
+++ b/t/43-sqlite-threads.t
@@ -1,0 +1,86 @@
+use v6;
+use Test;
+use DBIish;
+
+plan 2;
+
+given DBIish.install-driver('SQLite') -> $driver {
+    unless $driver.version {
+        skip-rest 'No SQLite3 library installed';
+        exit;
+    }
+    unless $driver.threadsafe {
+        skip-rest 'SQLite3 library was not compiled threadsafe';
+        exit;
+    }
+}
+
+my $database = IO::Path.new('dbdish-sqlite-test-threaded.sqlite3');
+$database.unlink if $database.e;
+END try $database.unlink;
+
+# Create a test table.
+my $dbh = DBIish.connect("SQLite", :$database);
+END try $dbh.dispose;
+$dbh.do('CREATE TABLE nom ( name varchar(50) )');
+
+# Check that it is possible to work with the database from multiple threads
+# at once with a single connection option. This works in SQLite's serialized
+# mode, which is the default.
+subtest 'Statements across threads on one connection' => {
+    my @inserters = do for ^5 -> $thread {
+        start {
+            for ^100 {
+                my $sth = $dbh.prepare(q:to/STATEMENT/);
+                    INSERT INTO nom (name)
+                    VALUES (?)
+                    STATEMENT
+                $sth.execute((('a'..'z').pick xx 40).join);
+                $sth.finish;
+            }
+        }
+    }
+
+    for @inserters.kv -> $idx, $i {
+        lives-ok { await $i }, "Inserting thread $idx completed";
+    }
+
+    given $dbh.prepare('SELECT COUNT(*) FROM nom') -> $sth {
+        $sth.execute;
+        is $sth.row()[0], 500, 'Correct number of rows were inserted';
+        $sth.finish;
+    }
+
+    $dbh.do('DELETE FROM nom');
+}
+
+# Check that it is possible to work with the database from multiple threads
+# at once with a connection object per thread
+subtest 'Multiple connections, one per thread' => {
+    my @inserters = do for ^5 -> $thread {
+        start {
+            my $dbht = DBIish.connect("SQLite", :$database);
+            for ^100 {
+                my $sth = $dbht.prepare(q:to/STATEMENT/);
+                    INSERT INTO nom (name)
+                    VALUES (?)
+                    STATEMENT
+                $sth.execute((('a'..'z').pick xx 40).join);
+                $sth.finish;
+            }
+            $dbht.dispose;
+        }
+    }
+
+    for @inserters.kv -> $idx, $i {
+        lives-ok { await $i }, "Inserting thread $idx completed";
+    }
+
+    given $dbh.prepare('SELECT COUNT(*) FROM nom') -> $sth {
+        $sth.execute;
+        is $sth.row()[0], 500, 'Correct number of rows were inserted';
+        $sth.finish;
+    }
+
+    $dbh.do('DELETE FROM nom');
+}


### PR DESCRIPTION
The changes in this PR primarily target getting SQLite working from multiple threads, since that's what I (well, my customer) needs. It includes a new test case that passes reliably ("on my machine") after the various fixes contained in this PR, plus some documentation about the changes.

A couple of the changes fix thread safety issues in DBIish more generally, and so this may have a positive effect on other databases drivers with regards to threads too (however, my guess would be that it's unlikely to be sufficient on its own).