### PR TITLE
Feedback wanted: Temporary failure error handling

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -27,6 +27,7 @@
         "DBDish::Oracle::StatementHandle"   : "lib/DBDish/Oracle/StatementHandle.pm6",
         "DBDish::Pg"                  : "lib/DBDish/Pg.pm6",
         "DBDish::Pg::Connection"      : "lib/DBDish/Pg/Connection.pm6",
+        "DBDish::Pg::ErrorHandling"   : "lib/DBDish/Pg/ErrorHandling.pm6",
         "DBDish::Pg::Native"          : "lib/DBDish/Pg/Native.pm6",
         "DBDish::Pg::StatementHandle" : "lib/DBDish/Pg/StatementHandle.pm6",
         "DBDish::SQLite"                  : "lib/DBDish/SQLite.pm6",

--- a/README.pod
+++ b/README.pod
@@ -189,6 +189,45 @@ For example:
 
 The payload is optional and will always be an empty string for PostgreSQL servers less than version 9.0.
 
+=head3 Statement Exceptions
+
+Exceptions for a query result are thrown as X::DBDish::DBError::Pg objects (inherits X::DBDish::DBError)
+and have the following additional attributes as provided by PostgreSQL
+(perl exception field ➡ PostgreSQL field name):
+
+  * message ➡ PG_DIAG_MESSAGE_PRIMARY
+  * message-detail ➡ PG_DIAG_MESSAGE_DETAIL
+  * message-hint ➡ PG_DIAG_MESSAGE_HINT
+  * context ➡ PG_DIAG_CONTEXT
+  * type ➡ PG_DIAG_SEVERITY_NONLOCALIZED
+  * type-localized ➡ PG_DIAG_SEVERITY
+  * state ➡ PG_DIAG_SQLSTATE
+  * statement-position ➡ PG_DIAG_STATEMENT_POSITION
+  * internal-position ➡ PG_DIAG_INTERNAL_POSITION
+  * internal-query ➡ PG_DIAG_INTERNAL_QUERY
+  * schema ➡ PG_DIAG_SCHEMA_NAME
+  * table ➡ PG_DIAG_TABLE_NAME
+  * column ➡ PG_DIAG_COLUMN_NAME
+  * datatype ➡ PG_DIAG_DATATYPE_NAME
+  * constraint ➡ PG_DIAG_CONSTRAINT_NAME
+  * source-file ➡ PG_DIAG_SOURCE_FILE
+  * source-line ➡ PG_DIAG_SOURCE_LINE
+  * source-function ➡ PG_DIAG_SOURCE_FUNCTION
+
+Please see the L<PostgreSQL documentation|https://www.postgresql.org/docs/current/static/libpq-exec.html#LIBPQ-PQRESULTERRORFIELD>
+for a detailed description of what each field contains.
+
+A special C<is-temporary()> method returns True if an immediate retry of the full transaction should be attempted:
+
+It is set to true when the L<SQLState|https://www.postgresql.org/docs/current/static/errcodes-appendix.html>
+is any of the following codes:
+
+  * Class 08\w{3}: All connection exceptions (possible network issues)
+  * 40001 serialization_failure
+  * 40P01 deadlock_detected
+  * Class 57\w{3}: Operator Intervention (early/forced connection termination)
+  * 72000 snapshot_too_old
+
 =head3 B<pg-socket>
 
 	my Int $socket = $db.pg-socket;

--- a/lib/DBDish/ErrorHandling.pm6
+++ b/lib/DBDish/ErrorHandling.pm6
@@ -11,6 +11,13 @@ package X::DBDish {
             "$!driver-name: $.why: $!native-message" ~
             ($!code ?? " ($!code)" !! '');
         }
+
+        # Individual drivers are expected to override this to return true for
+        # errors which may succeed if retried immediately.
+        # Serialization failure, deadlocks, network disconnects, etc.
+        method is-temporary {
+            False;
+        }
     }
     class ConnectionFailed is DBError {
         has $.why = "Can't connect";

--- a/lib/DBDish/Pg/ErrorHandling.pm6
+++ b/lib/DBDish/Pg/ErrorHandling.pm6
@@ -1,0 +1,64 @@
+use v6;
+need DBDish::ErrorHandling;
+use DBDish::Pg::Native;
+
+package X::DBDish {
+    class DBError::Pg is X::DBDish::DBError {
+        has $.sqlstate is required;
+        has $.message-detail;
+        has $.message-hint;
+        has $.context;
+        has $.type;
+        has $.type-localized;
+
+        has $.statement-position;
+        has $.internal-position;
+        has $.internal-query;
+
+        has $.schema;
+        has $.table;
+        has $.column;
+        has $.datatype;
+        has $.constraint;
+
+        has $.source-file;
+        has $.source-line;
+        has $.source-function;
+
+        has $.result;
+
+        submethod BUILD(:$!result) {
+            $!sqlstate = $!result.PQresultErrorField(PG_DIAG_SQLSTATE);
+
+            $!message-detail = $!result.PQresultErrorField(PG_DIAG_MESSAGE_DETAIL);
+            $!message-hint = $!result.PQresultErrorField(PG_DIAG_MESSAGE_HINT);
+            $!context = $!result.PQresultErrorField(PG_DIAG_CONTEXT);
+            $!type = $!result.PQresultErrorField(PG_DIAG_SEVERITY_NONLOCALIZED);
+            $!type-localized = $!result.PQresultErrorField(PG_DIAG_SEVERITY);
+
+            $!statement-position = $!result.PQresultErrorField(PG_DIAG_STATEMENT_POSITION);
+            $!internal-position = $!result.PQresultErrorField(PG_DIAG_INTERNAL_POSITION);
+            $!internal-query = $!result.PQresultErrorField(PG_DIAG_INTERNAL_QUERY);
+
+            $!schema = $!result.PQresultErrorField(PG_DIAG_SCHEMA_NAME);
+            $!table = $!result.PQresultErrorField(PG_DIAG_TABLE_NAME);
+            $!column = $!result.PQresultErrorField(PG_DIAG_COLUMN_NAME);
+            $!datatype = $!result.PQresultErrorField(PG_DIAG_DATATYPE_NAME);
+            $!constraint = $!result.PQresultErrorField(PG_DIAG_CONSTRAINT_NAME);
+
+            $!source-file = $!result.PQresultErrorField(PG_DIAG_SOURCE_FILE);
+            $!source-line = $!result.PQresultErrorField(PG_DIAG_SOURCE_LINE);
+            $!source-function = $!result.PQresultErrorField(PG_DIAG_SOURCE_FUNCTION);
+        }
+
+        # Errors which should cause a retry loop within the calling application include:
+        #  - Class 08\w{3}: All connection exceptions (possible network issues)
+        #  - 40001 serialization_failure
+        #  - 40P01 deadlock_detected
+        #  - Class 57\w{3}: Operator Intervention (early/forced connection termination)
+        #  - 72000 snapshot_too_old
+        method is-temporary {
+           so $.sqlstate ~~ /^ '08'<[alnum]> ** 3 | '40001'| '40P01' | '57'<[alnum]> ** 3 | '72000' $/;
+        }
+    }
+}

--- a/lib/DBDish/Pg/Native.pm6
+++ b/lib/DBDish/Pg/Native.pm6
@@ -36,6 +36,7 @@ class PGresult    is export is repr('CPointer') {
     method PQnparams(--> int32) is native(LIB) { * }
     method PQntuples(--> int32) is native(LIB) { * }
     method PQresultErrorMessage(--> str) is native(LIB) { * }
+    method PQresultErrorField(int32 $field_number --> Str) is native(LIB) { * }
     method PQresultStatus(--> int32) is native(LIB) { * }
     method PQgetlength(int32, int32 --> int32) is native(LIB) { * }
     method PQfformat(int32 --> int32) is native(LIB) { * }
@@ -360,5 +361,26 @@ constant PGRES_NON_FATAL_ERROR is export = 6;
 constant PGRES_FATAL_ERROR     is export = 7;
 constant PGRES_COPY_BOTH       is export = 8;
 constant PGRES_SINGLE_TUPLE    is export = 9;
+
+enum ResultErrorField is export (
+    PG_DIAG_SEVERITY              => ord('S'),
+    PG_DIAG_SEVERITY_NONLOCALIZED => ord('V'),
+    PG_DIAG_SQLSTATE              => ord('C'),
+    PG_DIAG_MESSAGE_PRIMARY       => ord('M'),
+    PG_DIAG_MESSAGE_DETAIL        => ord('D'),
+    PG_DIAG_MESSAGE_HINT          => ord('H'),
+    PG_DIAG_STATEMENT_POSITION    => ord('P'),
+    PG_DIAG_INTERNAL_POSITION     => ord('p'),
+    PG_DIAG_INTERNAL_QUERY        => ord('q'),
+    PG_DIAG_CONTEXT               => ord('W'),
+    PG_DIAG_SCHEMA_NAME           => ord('s'),
+    PG_DIAG_TABLE_NAME            => ord('t'),
+    PG_DIAG_COLUMN_NAME           => ord('c'),
+    PG_DIAG_DATATYPE_NAME         => ord('d'),
+    PG_DIAG_CONSTRAINT_NAME       => ord('n'),
+    PG_DIAG_SOURCE_FILE           => ord('F'),
+    PG_DIAG_SOURCE_LINE           => ord('L'),
+    PG_DIAG_SOURCE_FUNCTION       => ord('R'),
+);
 
 # vim: ft=perl6 et

--- a/t/38-pg-errors.t
+++ b/t/38-pg-errors.t
@@ -1,0 +1,120 @@
+use v6;
+use Test;
+use DBIish;
+need DBDish::Pg::ErrorHandling;
+
+plan 7;
+
+my %con-parms;
+# If env var set, no parameter needed.
+%con-parms<database> = 'dbdishtest' unless %*ENV<PGDATABASE>;
+%con-parms<user> = 'postgres' unless %*ENV<PGUSER>;
+my $dbh;
+
+try {
+  $dbh = DBIish.connect('Pg', |%con-parms);
+  CATCH {
+    when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
+        diag "$_\nCan't continue.";
+    }
+    default { .throw; }
+  }
+}
+without $dbh {
+    skip-rest 'prerequisites failed';
+    exit;
+}
+
+ok $dbh,    'Connected';
+
+my $db-version = $dbh.server-version;
+if $db-version !~~ /^ '9.'<[3 .. 6]> | 1\d / {
+   skip-rest "Pg $db-version does not support full exception structure";
+   exit;
+}
+
+# Typical error from Pg
+my $ex;
+throws-like {
+    $dbh.do(q{SELECT nocolumn FROM pg_class;});
+
+    CATCH {
+        default {
+            $ex = $_;
+            .throw;
+        }
+    }
+}, X::DBDish::DBError::Pg, 'Incorrect column',
+    message => /'column "nocolumn" does not exist'/,
+    sqlstate   => '42703',
+    type    => 'ERROR',
+    type-localized => /^ .+ $/,
+    source-file   => 'parse_relation.c',
+    source-line   => / \d+ /,
+    source-function => 'errorMissingColumn';
+ok $ex.is-temporary === False, 'Incorrect column: not temporary';
+
+
+# All parameters
+throws-like {
+    $dbh.do(q:to/_QUERY_/);
+      DO LANGUAGE plpgsql $$
+        BEGIN RAISE EXCEPTION 'Field Test' USING
+                ERRCODE = 'ERR99', DETAIL = 'Detail', HINT = 'Hint',
+                COLUMN = 'Column', CONSTRAINT = 'Constraint', DATATYPE = 'Datatype',
+                TABLE = 'Table', SCHEMA = 'Schema';
+        END;$$;
+    _QUERY_
+
+    # Copy needed for additional testing. throws-like cannot handle Bool type
+    CATCH {
+        default {
+            $ex = $_;
+            .throw;
+        }
+    }
+}, X::DBDish::DBError::Pg, 'Raise Exception',
+    sqlstate => 'ERR99',
+    message => /'DBDish::Pg:' .* 'Error: Field Test'/,
+    native-message => 'Field Test',
+    message-detail => 'Detail',
+    message-hint => 'Hint',
+    context => 'PL/pgSQL function inline_code_block line 2 at RAISE',
+    type    => 'ERROR',
+    schema => 'Schema',
+    table => 'Table',
+    column => 'Column',
+    datatype => 'Datatype',
+    constraint => 'Constraint',
+    type-localized => /^ .+ $/,
+    source-file => 'pl_exec.c',
+    source-line => / \d+ /,
+    source-function => 'exec_stmt_raise';
+ok $ex.is-temporary === False, 'Raise Exception: not temporary';
+
+
+# Sample of a retryable error (result may be different on immediate retry).
+throws-like {
+    $dbh.do(q:to/_QUERY_/);
+      DO LANGUAGE plpgsql $$
+        BEGIN RAISE EXCEPTION 'Fake serialization failure' USING ERRCODE = '40001';
+      END;$$;
+    _QUERY_
+
+    CATCH {
+        default {
+            $ex = $_;
+            .throw;
+        }
+    }
+}, X::DBDish::DBError::Pg, 'Raise Temporary Exception',
+    message => /'Fake serialization failure'/,
+    context => 'PL/pgSQL function inline_code_block line 2 at RAISE',
+    sqlstate   => '40001',
+    type    => 'ERROR',
+    type-localized => /^ .+ $/,
+    source-file => 'pl_exec.c',
+    source-line => / \d+ /,
+    source-function => 'exec_stmt_raise';
+ok $ex.is-temporary === True, 'Raise Temporary Exception: temporary';
+


### PR DESCRIPTION
This is a WIP needing feedback.

Ideally the framework (Cro, Bailador, etc.) would have a retry loop and be able to catch temporary type errors and do the retry handling itself.

Outstanding issues
---
1.  throws-like expects "Bool::False" but is-temporary only returns "False". This feels like a throws-like problem.
1. Should SQLState be up a level? DBI on perl5 has non-SQL databases so I've opted to apply it to the Pg exception only but every SQL database should be setting the SQLState in a consistent manner. State exceptions are a part of the spec.
1. To determine it's a ::Pg exception a file requires "need DBDish::Pg::ErrorHandling;". Is it possible to eliminate that so the standard "use DBDish;" covers it?

I'm quite new to Perl6. I didn't see anything in the documentation like an X-Temporary Role to decorate exception objects but there is probably a more generic way of achieving this.


Commit message
---
DBs have numerous temporary errors from deadlocks to serialization failures to network failures. SQLState contains the error code (largely standardized across SQL DBs, but not completely) for various situations which may require a retry or allow the client to perform other correctable work.

Export sqlstate and all other available fields for Pg in X::DBDish::DBError::Pg (extends X::DBDish::DBError).

While here, shorten the message to just the error component for Pg. Detail and Hint are available via other fields and is quite noisy (it typically starts with Error: ERROR: as DBIish adds an 'Error:' prefix too).

Add is-temporary which checks if the sqlstate for Pg is a temporary failure and the transaction should typically be retried immediately by the client. These states for Pg include:
  Class 08\w{3}: All connection exceptions (possible network issues)
  40001 serialization_failure
  40P01 deadlock_detected
  Class 57\w{3}: Operator Intervention (early/forced connection termination)
  72000 snapshot_too_old

The intent is that a tool like Cro can check for is-temporary across all DB drivers and restart working on the request with very little assistance from the developer other than perhaps a "sub routes(:restartable)" type markup to indicate their code is safe to re-execute.