### PR TITLE
Performance improvements, with a focus on SQLite and re-use of statement handles

### DIFF
--- a/lib/DBDish/ErrorHandling.pm6
+++ b/lib/DBDish/ErrorHandling.pm6
@@ -55,7 +55,7 @@ role DBDish::ErrorHandling is export {
         $!RaiseError and .throw or .fail;
     }
 
-    method !set-err($code, $errstr) is hidden-from-backtrace {
+    method !set-err(Int $code, Str $errstr) is hidden-from-backtrace {
         self!error-dispatch: X::DBDish::DBError.new(
             :$code, :native-message($errstr), :$.driver-name
         );

--- a/lib/DBDish/ErrorHandling.pm6
+++ b/lib/DBDish/ErrorHandling.pm6
@@ -25,9 +25,7 @@ role DBDish::ErrorHandling is export {
 
     method set-last-exception($e) {
         $!last-exception = $e;
-        if $!parent.^can('set-last-exception') {
-            $!parent.set-last-exception($e);
-        }
+        $!parent.?set-last-exception($e);
     }
 
     method err(--> Int)  {

--- a/lib/DBDish/SQLite/StatementHandle.pm6
+++ b/lib/DBDish/SQLite/StatementHandle.pm6
@@ -32,8 +32,9 @@ submethod BUILD(:$!conn!, :$!parent!,
 method execute(*@params) {
     self!enter-execute(@params.elems, $!param-count);
 
-    for @params.kv -> $idx, $v {
-        self!handle-error(sqlite3_bind($!statement_handle, $idx + 1, $v));
+    my $num-params = @params.elems;
+    loop (my $idx = 0; $idx < $num-params; $idx++) {
+        self!handle-error(sqlite3_bind($!statement_handle, $idx + 1, @params[$idx]));
     }
     $!row_status = sqlite3_step($!statement_handle);
     if $!row_status == SQLITE_ROW | SQLITE_DONE {

--- a/lib/DBDish/SQLite/StatementHandle.pm6
+++ b/lib/DBDish/SQLite/StatementHandle.pm6
@@ -14,9 +14,7 @@ has Int $!row_status;
 has $!field_count;
 
 method !handle-error($status) {
-    if $status == SQLITE_OK {
-        self.reset-err;
-    } else {
+    unless $status == SQLITE_OK {
         self!set-err($status, sqlite3_errmsg($!conn));
     }
 }
@@ -40,6 +38,7 @@ method execute(*@params) {
     $!row_status = sqlite3_step($!statement_handle);
     if $!row_status == SQLITE_ROW | SQLITE_DONE {
         my $rows = $!field_count ?? 0 !! sqlite3_changes($!conn); # Non SELECT
+        self.reset-err;
         self!done-execute($rows, $!field_count);
     } else {
         self!set-err($!row_status, sqlite3_errmsg($!conn));

--- a/lib/DBDish/SQLite/StatementHandle.pm6
+++ b/lib/DBDish/SQLite/StatementHandle.pm6
@@ -13,7 +13,7 @@ has $!param-count;
 has Int $!row_status;
 has $!field_count;
 
-method !handle-error($status) {
+method !handle-error(Int $status) {
     unless $status == SQLITE_OK {
         self!set-err($status, sqlite3_errmsg($!conn));
     }
@@ -29,7 +29,7 @@ submethod BUILD(:$!conn!, :$!parent!,
     }
 }
 
-method execute(*@params) {
+method execute(*@params is raw) {
     self!enter-execute(@params.elems, $!param-count);
 
     my $num-params = @params.elems;

--- a/lib/DBDish/StatementHandle.pm6
+++ b/lib/DBDish/StatementHandle.pm6
@@ -22,6 +22,7 @@ has Bool $.Finished = True;
 has Int $!affected_rows;
 has @!column-name;
 has @!column-type;
+has $!which = self.WHICH;
 
 # My defined interface
 method execute(*@ --> Int) { ... }
@@ -30,7 +31,7 @@ method _row(--> Array) { ... }
 method _free() { ... }
 
 method !ftr() {
-    $.parent.last-sth-id = self.WHICH;
+    $.parent.last-sth-id = $!which;
 }
 
 method !enter-execute(int $got = 0, int $expect = 0) {

--- a/lib/DBDish/StatementHandle.pm6
+++ b/lib/DBDish/StatementHandle.pm6
@@ -24,7 +24,7 @@ has @!column-name;
 has @!column-type;
 
 # My defined interface
-method execute(*@ --> IntTrue) { ... }
+method execute(*@ --> Int) { ... }
 method finish(--> Bool) { ... }
 method _row(--> Array) { ... }
 method _free() { ... }
@@ -69,7 +69,10 @@ submethod DESTROY() {
 }
 
 method rows {
-    $!affected_rows but IntTrue;
+    my constant TRUE_ZERO = 0 but IntTrue;
+    $!affected_rows.defined
+            ?? $!affected_rows || TRUE_ZERO
+            !! Int
 }
 
 method row(:$hash) {


### PR DESCRIPTION
A benchmark of doing a million inserts to a SQLite database using DBIish was reported as being around 120x slower than with Perl 5 DBI. Ain't nobody got time for that.

I did some profiling and analysis of the results, and came up with this set of patches. Some of them are specific to SQLite, but the majority - including the most dramatic improvements - touch code that is shared by the various database drivers.

Taken together with a patch for NativeCall to fix a bottleneck there, and noting that I'm running not only Rakudo HEAD but also a branch with some further optimizations, I now measure DBIish being "just" 20x slower at this benchmark. So a good way to go yet until we're "good", *but* taken together with the Rakudo/NativeCall improvements that still sees DBIish being 5x-6x faster at it than before.