### PR TITLE
Change constant LIB to sub LIB for NativeCall.native trait

### DIFF
--- a/lib/DBDish/mysql/Native.pm6
+++ b/lib/DBDish/mysql/Native.pm6
@@ -5,9 +5,11 @@ use NativeCall;
 use NativeLibs;
 use NativeHelpers::Blob;
 
-constant LIB = NativeLibs::Searcher.at-runtime(
-    Rakudo::Internals.IS-WIN ?? 'mysql' !! 'mysqlclient',
-    'mysql_init', 16..20);
+sub LIB {
+    NativeLibs::Searcher.at-runtime(
+        Rakudo::Internals.IS-WIN ?? 'mysql' !! 'mysqlclient',
+        'mysql_init', 16..20).();
+}
 
 #From mysql_com.h
 enum mysql-field-type is export (


### PR DESCRIPTION
Today I have tried to work with this module in following docker image:
`jjmerelo/alpine-perl6                         latest`

And I got problems like this:
```
DBIish: DBDish::mysql needs 'mysqlclient', not found
  in block  at /root/DBIish/lib/DBIish.pm6 (DBIish) line 38
  in any  at /root/DBIish/lib/.precomp/66C92D2F17D08B89FEC541B7D4E05F5B1EE9A1EE/1C/1CA5208A6CF88323A3E082CE410A3C0FA838A19B line 1
  in method setup at /root/.rakudobrew/moar-master/install/share/perl6/sources/947BDAB9F96E0E5FCCB383124F923A6BF6F8D76B (NativeCall) line 283
  in method CALL-ME at /root/.rakudobrew/moar-master/install/share/perl6/sources/947BDAB9F96E0E5FCCB383124F923A6BF6F8D76B (NativeCall) line 570
  in method connect at /root/DBIish/lib/DBDish/mysql.pm6 (DBDish::mysql) line 12
  in method connect at /root/DBIish/lib/DBIish.pm6 (DBIish) line 45
  in block <unit> at -e line 1

```

I've digged this to the following boilerplate:

```
# perl6 -MNativeCall -e 'constant LIB = ( "mysqlclient" ); sub mysql_get_client_version(--> int32) is native(LIB) { * }; say mysql_get_client_version'
60111
# perl6 -MNativeCall -e 'constant LIB = sub { "mysqlclient" }; sub mysql_get_client_version(--> int32) is native(LIB) { * }; say mysql_get_client_version'
Cannot locate native library 'mysqlclient': mysqlclient: cannot open shared object file: No such file or directory
```

Discussed on #perl6 channel, and got explanatioon:
```
16:58 < scimon> m: constant CON = sub{ "Hmnmm"}; say CON; 
16:58 < camelia> rakudo-moar 21ae9f3e2: OUTPUT: «sub { }␤»
16:59 < scimon> m: constant CON = sub{ "Hmnmm"}; say CON.(); 
16:59 < camelia> rakudo-moar 21ae9f3e2: OUTPUT: «Hmnmm␤»

```

And yes, it works:
```
perl6 -MNativeCall -e 'constant LIB = sub { "mysqlclient" }; sub mysql_get_client_version(--> int32) is native(LIB.()) { * }; say mysql_get_client_version'
60111
```


Tried following workaround:
```
perl6 -MNativeCall -e 'sub LIB { "mysqlclient" }; sub mysql_get_client_version(--> int32) is native(LIB) { * }; say mysql_get_client_version' 
60111
```


So proposing this merge request to fix this problem.