### PR TITLE
Return insert ids when requested

### DIFF
--- a/lib/DBDish/Pg/StatementHandle.pm6
+++ b/lib/DBDish/Pg/StatementHandle.pm6
@@ -73,6 +73,17 @@ method execute(*@params) {
                                     Null, Null, 0)
         !! $!pg_conn.PQexec($!statement);
 
+    if $!statement ~~ /:i insert.*returning/ {
+      my @returns;
+
+      my $count = 0;
+      while $count < $!result.PQntuples {
+        @returns.push: $!result.PQgetvalue($count++, 0);
+      }
+
+      return @returns;
+    }
+
     self!set-err(PGRES_FATAL_ERROR, $!pg_conn.PQerrorMessage).fail unless $!result;
 
     $!current_row = 0;

--- a/t/33-pg-insert-ids.t
+++ b/t/33-pg-insert-ids.t
@@ -1,0 +1,65 @@
+
+use v6;
+use DBIish;
+use Test;
+
+plan 4;
+
+my %con-parms;
+%con-parms<database> = 'dbdishtest' unless %*ENV<PGDATABASE>;
+%con-parms<user> = 'postgres' unless %*ENV<PGUSER>;
+my $dbh;
+
+try {
+  $dbh = DBIish.connect('Pg', |%con-parms);
+  CATCH {
+    when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
+      diag "$_\nCan't continue.";
+    }
+    default { .throw; }
+  }
+}
+
+without $dbh {
+  skip-rest 'prerequisites failed';
+  exit;
+}
+
+my $sth = $dbh.do(q:to/SQL/);
+  DROP TABLE IF EXISTS rakuists;
+SQL
+
+$sth = $dbh.do(q:to/SQL/);
+  CREATE TABLE rakuists (
+    id SERIAL,
+    name VARCHAR NOT NULL
+  );
+SQL
+
+$sth = $dbh.do(q:to/SQL/);
+  INSERT INTO rakuists (name)
+  VALUES ('Jonathan Worthington')
+  RETURNING id;
+SQL
+
+ok $sth[0] == 1, '"do" returns an insert id';
+
+$sth = $dbh.do(q:to/SQL/);
+  INSERT INTO rakuists (name)
+  VALUES ('Moritz Lenz'), ('Patrick R. Michaud')
+  RETURNING id;
+SQL
+
+ok $sth[0] == 2, '"do" with multiple values returns the first insert id';
+ok $sth[1] == 3, '"do" with multiple values returns the second insert id';
+
+$sth = $dbh.prepare(q:to/SQL/);
+  INSERT INTO rakuists (name)
+  VALUES (?)
+  RETURNING id;
+SQL
+
+ok $sth.execute('Elizabeth Mattijsen')[0] == 4, '"prepare" returns an insert id';
+
+$sth.dispose;
+$dbh.dispose;

--- a/t/36-pg-array.t
+++ b/t/36-pg-array.t
@@ -4,7 +4,7 @@ use v6;
 use DBIish;
 use Test;
 
-plan 7;
+plan 8;
 my %con-parms;
 # If env var set, no parameter needed.
 %con-parms<database> = 'dbdishtest' unless %*ENV<PGDATABASE>;
@@ -47,6 +47,8 @@ $sth = $dbh.do(q:to/STATEMENT/);
       '{511.123, 622.345,1}'
     );
 STATEMENT
+
+ok $sth == 1, 'returns the insert count';
 
 $sth = $dbh.prepare(q:to/STATEMENT/);
     SELECT name, pay_by_quarter, schedule, salary_by_month


### PR DESCRIPTION
If an insert statement requests a 'returning' field value then do that, otherwise continue to return the insert count.