### PR TITLE
Make table names unique

### DIFF
--- a/t/24-mysql-types.t
+++ b/t/24-mysql-types.t
@@ -33,24 +33,24 @@ without $dbh {
 }
 
 ok $dbh,    'Connected';
-lives-ok { $dbh.do('DROP TABLE IF EXISTS test') }, 'Clean';
+lives-ok { $dbh.do('DROP TABLE IF EXISTS test_types') }, 'Clean';
 my $hasjson = $dbh.drv.version after v5.7.8;
 my $field = $hasjson ?? 'JSON' !! 'varchar';
 diag "want test '$field'";
 lives-ok {
     $dbh.do(qq|
-    CREATE TABLE test (
+    CREATE TABLE test_types (
 	col1 $field
     )|)
 }, 'Table created';
 
-my $sth = $dbh.prepare('INSERT INTO test (col1) VALUES(?)');
+my $sth = $dbh.prepare('INSERT INTO test_types (col1) VALUES(?)');
 lives-ok {
     $sth.execute('{"key1": "value1"}');
 }, 'Insert Perl6 values';
 $sth.dispose;
 
-$sth = $dbh.prepare('SELECT col1 FROM test');
+$sth = $dbh.prepare('SELECT col1 FROM test_types');
 my @coltype = $sth.column-types;
 ok @coltype eqv [Str],			    'Column-types';
 
@@ -83,7 +83,7 @@ if $hasjson {
     $dbh.dynamic-types{245} = JSON;
     is $dbh.dynamic-types{245}, JSON,	    'Changed';
 
-    $sth = $dbh.prepare('SELECT col1 FROM test');
+    $sth = $dbh.prepare('SELECT col1 FROM test_types');
     ok $sth.execute,			    'Executed';
     isa-ok $sth.column-types[0], JSON;
     isa-ok $sth.row[0], Hash,	            'Converted';
@@ -91,4 +91,4 @@ if $hasjson {
     skip-rest "No suport for JSON type";
 }
 
-$dbh.do('DROP TABLE IF EXISTS test');
+$dbh.do('DROP TABLE IF EXISTS test_types');

--- a/t/26-mysql-blob.t
+++ b/t/26-mysql-blob.t
@@ -22,15 +22,15 @@ without $dbh {
 }
 
 ok $dbh,    'Connected';
-lives-ok { $dbh.do('DROP TABLE IF EXISTS test') }, 'Clean';
+lives-ok { $dbh.do('DROP TABLE IF EXISTS test_blob') }, 'Clean';
 lives-ok {
     $dbh.do(q|
-    CREATE TABLE test (
+    CREATE TABLE test_blob (
 	id INT(3) NOT NULL DEFAULT 0, 
 	name BLOB)|)
 }, 'Table created';
 my $blob = Buf.new(^256);
-my $query = 'INSERT INTO test VALUES(?, ?)';
+my $query = 'INSERT INTO test_blob VALUES(?, ?)';
 
 with $dbh.prepare($query) {
     LEAVE { .dispose }
@@ -39,7 +39,7 @@ with $dbh.prepare($query) {
     ok .execute(2, Buf),		'Executed without buf';
 } else { .fail }
 
-with $dbh.prepare('SELECT name FROM test WHERE id = ?') {
+with $dbh.prepare('SELECT name FROM test_blob WHERE id = ?') {
     LEAVE { .dispose }
     ok $_,				'SELECT prepared';
     ok .execute(1),			'Executed for 1';
@@ -57,5 +57,5 @@ with $dbh.prepare('SELECT name FROM test WHERE id = ?') {
 } else { .fail }
 
 lives-ok {
-    $dbh.do('DROP TABLE IF EXISTS test');
+    $dbh.do('DROP TABLE IF EXISTS test_blob');
 },					'All clean';

--- a/t/27-mysql-datetime.t
+++ b/t/27-mysql-datetime.t
@@ -22,27 +22,27 @@ without $dbh {
 }
 
 ok $dbh,    'Connected';
-lives-ok { $dbh.do('DROP TABLE IF EXISTS test') }, 'Clean';
+lives-ok { $dbh.do('DROP TABLE IF EXISTS test_datetime') }, 'Clean';
 my $subsec = $dbh.drv.version after v5.6.4;
 my $field = 'TIMESTAMP'; $field ~= '(6)' if $subsec;
 diag "Using $field";
 lives-ok {
     $dbh.do(qq|
-    CREATE TABLE test (
+    CREATE TABLE test_datetime (
 	adate DATE,
 	atime TIME,
 	atimestamp $field 
     )|);
 }, 'Table created';
 
-my $sth = $dbh.prepare('INSERT INTO test (adate, atimestamp) VALUES(?, ?)');
+my $sth = $dbh.prepare('INSERT INTO test_datetime (adate, atimestamp) VALUES(?, ?)');
 my $now = DateTime.now;
 $now .= truncated-to('second') unless $subsec;
 lives-ok {
     $sth.execute($now.Date, $now);
 }, 'Insert Perl6 values';
 $sth.dispose;
-$sth = $dbh.prepare('SELECT adate, atimestamp FROM test');
+$sth = $dbh.prepare('SELECT adate, atimestamp FROM test_datetime');
 my @coltype = $sth.column-types;
 ok @coltype eqv [Date, DateTime],	    'Column-types';
 
@@ -62,4 +62,4 @@ if $subsec {
     skip "Without subsecond precision",  1;
 }
 diag $now.Instant - $datetime.Instant;
-$dbh.do('DROP TABLE IF EXISTS test');
+$dbh.do('DROP TABLE IF EXISTS test_datetime');

--- a/t/34-pg-types.t
+++ b/t/34-pg-types.t
@@ -28,20 +28,20 @@ ok $dbh,    'Connected';
 
 # Be less verbose;
 $dbh.do('SET client_min_messages TO WARNING');
-lives-ok { $dbh.do('DROP TABLE IF EXISTS test') }, 'Clean';
+lives-ok { $dbh.do('DROP TABLE IF EXISTS test_types') }, 'Clean';
 lives-ok {
     $dbh.do(q|
-    CREATE TABLE test (
+    CREATE TABLE test_types (
 	col1 text
     )|)
 }, 'Table created';
 
-my $sth = $dbh.prepare('INSERT INTO test (col1) VALUES(?)');
+my $sth = $dbh.prepare('INSERT INTO test_types (col1) VALUES(?)');
 lives-ok {
     $sth.execute('test');
 }, 'Insert Perl6 values';
 $sth.dispose;
-$sth = $dbh.prepare('SELECT col1 FROM test');
+$sth = $dbh.prepare('SELECT col1 FROM test_types');
 my @coltype = $sth.column-types;
 ok @coltype eqv [Str],	    'Column-types';
 
@@ -53,4 +53,4 @@ $dbh.Converter{Str} = sub ($) { 'changed' };
 is $sth.execute, 1,			    '1 row';
 ($col1) = $sth.row;
 is $col1, 'changed',		    'Changed';
-$dbh.do('DROP TABLE IF EXISTS test');
+$dbh.do('DROP TABLE IF EXISTS test_types');

--- a/t/36-pg-blob.t
+++ b/t/36-pg-blob.t
@@ -25,19 +25,19 @@ without $dbh {
 }
 
 ok $dbh,    'Connected';
-lives-ok { $dbh.do('DROP TABLE IF EXISTS test') }, 'Clean';
+lives-ok { $dbh.do('DROP TABLE IF EXISTS test_blob') }, 'Clean';
 lives-ok {
     $dbh.do(q|
-    CREATE TABLE test (
+    CREATE TABLE test_blob (
 	id INT NOT NULL DEFAULT 0, 
 	name bytea)|)
 }, 'Table created';
 my $blob = Buf.new(^256);
-my $query = 'INSERT INTO test VALUES(?, ?)';
+my $query = 'INSERT INTO test_blob VALUES(?, ?)';
 ok (my $sth = $dbh.prepare($query)),	 "Prepared '$query'";
 ok $sth.execute(1, $blob),		 'Executed with buf';
 ok $sth.execute(2, Buf),		 'Executed without buf';
-ok $sth = $dbh.prepare('SELECT name FROM test WHERE id = ?'), 'SELECT prepared';
+ok $sth = $dbh.prepare('SELECT name FROM test_blob WHERE id = ?'), 'SELECT prepared';
 ok $sth.execute(1), 'Executed for 1';
 ok (my @res = $sth.row), 'Get a row';
 is @res.elems,  1,	 'One field';

--- a/t/36-pg-enum.t
+++ b/t/36-pg-enum.t
@@ -35,21 +35,21 @@ lives-ok {
 }, 'Type created';
 
 
-lives-ok { $dbh.do('DROP TABLE IF EXISTS test') }, 'Clean';
+lives-ok { $dbh.do('DROP TABLE IF EXISTS test_enum') }, 'Clean';
 lives-ok {
     $dbh.do(q|
-    CREATE TABLE test (
+    CREATE TABLE test_enum (
 	id INT NOT NULL DEFAULT 0, 
 	yeah yesno)|)
 }, 'Table created';
 
-my $query = 'INSERT INTO test VALUES(?, ?)';
+my $query = 'INSERT INTO test_enum VALUES(?, ?)';
 ok my $sth = $dbh.prepare($query), "Prepared '$query'";
 ok $sth.execute(1, 'Yes'),		 'Executed with Yes';
 ok $sth.execute(2, 'No'),		 'Executed with No';
 ok $sth.execute(3, Nil),		 'Executed with null';
 
-ok $sth = $dbh.prepare('SELECT yeah FROM test WHERE id = ?'), 'SELECT prepared';
+ok $sth = $dbh.prepare('SELECT yeah FROM test_enum WHERE id = ?'), 'SELECT prepared';
 ok $sth.execute(1), 'Executed for 1';
 ok (my @res = $sth.row), 'Get a row';
 
@@ -89,7 +89,7 @@ for @enum -> @option {
     };
     ok ($dbh.Converter{YesNo} = $yesno),   'Install the YesNo converter';
 
-    ok $sth = $dbh.prepare('SELECT yeah FROM test WHERE id = ?'), 'SELECT prepared';
+    ok $sth = $dbh.prepare('SELECT yeah FROM test_enum WHERE id = ?'), 'SELECT prepared';
     ok $sth.execute(1), 'Executed for 1';
     ok (@res = $sth.row), 'Get a row';
     is @res.elems,  1,	 'One field';
@@ -103,4 +103,4 @@ for @enum -> @option {
     is @res.elems,  1,	 'One field';
 }
 
-$dbh.do('DROP TABLE IF EXISTS test');
+$dbh.do('DROP TABLE IF EXISTS test_enum');

--- a/t/37-pg-datetime.t
+++ b/t/37-pg-datetime.t
@@ -27,10 +27,10 @@ without $dbh {
 ok $dbh,    'Connected';
 # Be less verbose;
 $dbh.do('SET client_min_messages TO WARNING');
-lives-ok { $dbh.do('DROP TABLE IF EXISTS test') }, 'Clean';
+lives-ok { $dbh.do('DROP TABLE IF EXISTS test_datetime') }, 'Clean';
 lives-ok {
     $dbh.do(q|
-    CREATE TABLE test (
+    CREATE TABLE test_datetime (
 	adate DATE,
 	atime TIME,
 	atimestamp TIMESTAMP WITH TIME ZONE,
@@ -38,7 +38,7 @@ lives-ok {
     )|)
 }, 'Table created';
 
-my $sth = $dbh.prepare('INSERT INTO test (adate, atimestamp) VALUES(?, ?)');
+my $sth = $dbh.prepare('INSERT INTO test_datetime (adate, atimestamp) VALUES(?, ?)');
 my $now = DateTime.now;
 lives-ok {
     $sth.execute($now, $now);
@@ -47,7 +47,7 @@ lives-ok {
     $sth.execute('today', 'now');
 }, 'Insert PostgreSQL literals';
 $sth.dispose;
-$sth = $dbh.prepare('SELECT adate, atimestamp FROM test');
+$sth = $dbh.prepare('SELECT adate, atimestamp FROM test_datetime');
 my @coltype = $sth.column-types;
 ok @coltype eqv [Date, DateTime],	    'Column-types';
 
@@ -61,4 +61,4 @@ is $datetime, $now,			    'Right now';
 is $date, $now.Date,			    'Today';
 isnt $datetime, $now,			    'Server drift';
 diag $datetime.Instant - $now.Instant;
-$dbh.do('DROP TABLE IF EXISTS test');
+$dbh.do('DROP TABLE IF EXISTS test_datetime');

--- a/t/46-sqlite-blob.t
+++ b/t/46-sqlite-blob.t
@@ -24,19 +24,19 @@ without $dbh {
 }
 
 ok $dbh,    'Connected';
-lives-ok { $dbh.do('DROP TABLE IF EXISTS test') }, 'Clean';
+lives-ok { $dbh.do('DROP TABLE IF EXISTS test_blob') }, 'Clean';
 lives-ok {
     $dbh.do(q|
-    CREATE TABLE test (
+    CREATE TABLE test_blob (
 	id INT NOT NULL DEFAULT 0, 
 	name bytea)|)
 }, 'Table created';
 my $blob = Buf.new(^256);
-my $query = 'INSERT INTO test VALUES(?, ?)';
+my $query = 'INSERT INTO test_blob VALUES(?, ?)';
 ok (my $sth = $dbh.prepare($query)),	 "Prepared '$query'";
 ok $sth.execute(1, $blob),		 'Executed with buf';
 ok $sth.execute(2, Buf),		 'Executed without buf';
-ok $sth = $dbh.prepare('SELECT name FROM test WHERE id = ?'), 'SELECT prepared';
+ok $sth = $dbh.prepare('SELECT name FROM test_blob WHERE id = ?'), 'SELECT prepared';
 $sth.column-types[0] = Buf;
 ok $sth.execute(1), 'Executed for 1';
 ok (my @res = $sth.row), 'Get a row';
@@ -50,6 +50,6 @@ is @res.elems,  1,	 'One field';
 $data = @res[0];
 ok $data ~~ Buf,         'Data is-a Buf';
 ok not $data.defined,    'But is NULL';
-$dbh.do('DROP TABLE IF EXISTS test');
+$dbh.do('DROP TABLE IF EXISTS test_blob');
 $dbh.dispose;
 $TDB.unlink

--- a/t/56-oracle-blob.t
+++ b/t/56-oracle-blob.t
@@ -24,7 +24,7 @@ without $dbh {
 
 my $dropper = q|
     BEGIN
-       EXECUTE IMMEDIATE 'DROP TABLE test';
+       EXECUTE IMMEDIATE 'DROP TABLE test_blob';
     EXCEPTION
        WHEN OTHERS THEN
 	  IF SQLCODE != -942 THEN
@@ -35,14 +35,14 @@ my $dropper = q|
 ok $dbh,    'Connected';
 lives-ok { $dbh.do($dropper) }, 'Clean';
 lives-ok {
-    $dbh.do(q|CREATE TABLE test (id NUMBER, name RAW(300) )|)
+    $dbh.do(q|CREATE TABLE test_blob (id NUMBER, name RAW(300) )|)
 }, 'Table created';
 my $blob = Buf.new(^256);
-my $query = 'INSERT INTO test VALUES(?, ?)';
+my $query = 'INSERT INTO test_blob VALUES(?, ?)';
 ok (my $sth = $dbh.prepare($query)),	 "Prepared '$query'";
 ok $sth.execute(1, $blob),		 'Executed with buf';
 ok $sth.execute(2, Buf),		 'Executed without buf';
-ok $sth = $dbh.prepare('SELECT name FROM test WHERE id = ?'), 'SELECT prepared';
+ok $sth = $dbh.prepare('SELECT name FROM test_blob WHERE id = ?'), 'SELECT prepared';
 ok $sth.execute(1), 'Executed for 1';
 ok (my @res = $sth.row), 'Get a row';
 is @res.elems,  1,	 'One field';

--- a/t/57-oracle-datetime.t
+++ b/t/57-oracle-datetime.t
@@ -24,7 +24,7 @@ without $dbh {
 ok $dbh,    'Connected';
 my $dropper = q|
     BEGIN
-       EXECUTE IMMEDIATE 'DROP TABLE test';
+       EXECUTE IMMEDIATE 'DROP TABLE test_datetime';
     EXCEPTION
        WHEN OTHERS THEN
           IF SQLCODE != -942 THEN
@@ -35,14 +35,14 @@ my $dropper = q|
 lives-ok { $dbh.do($dropper) }, 'Clean';
 lives-ok {
     $dbh.do(qq|
-    CREATE TABLE test (
+    CREATE TABLE test_datetime (
 	adate DATE,
 	atimestamp TIMESTAMP(6) WITH TIME ZONE
     )|);
 }, 'Table created';
 
 my $sth = $dbh.prepare(
-    q|INSERT INTO test (adate, atimestamp) VALUES(?, ?)|);
+    q|INSERT INTO test_datetime (adate, atimestamp) VALUES(?, ?)|);
 my $now = DateTime.now;
 
 lives-ok {
@@ -53,7 +53,7 @@ lives-ok {
 },                                           'Can insert Perl6 values';
 $sth.dispose;
 
-$sth = $dbh.prepare('SELECT adate, atimestamp FROM test');
+$sth = $dbh.prepare('SELECT adate, atimestamp FROM test_datetime');
 my @coltype = $sth.column-types;
 ok @coltype eqv [Date, DateTime],	    'Column-types match';
 


### PR DESCRIPTION
This ensures that one test will not drop a table in use by another test during parallel test execution.