### PR TITLE
Make the allrows example consistent and a bit more obvious

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -111,9 +111,9 @@ or C<hash-of-array>
 
 Example:
 
-    my @data = $sth.allrows(); # [[1, 2, 3], [4, 5, 6]]
-    my @data = $sth.allrows(:array-of-hash); # [ ( a => 1, b => 2), ( a => 3, b => 4) ]
-    my %data = $sth.allrows(:hash-of-array); # a => [1, 3], b => [2, 4]
+    my @data = $sth.allrows(); # [[1, 'val1'], [3, 'val2']]
+    my @data = $sth.allrows(:array-of-hash); # [ ( a => 1, b => 'val1'), ( a => 3, b => 'val2') ]
+    my %data = $sth.allrows(:hash-of-array); # a => [1, 3], b => ['val1', 'val2']
 
 =head1 INSTALLATION
 


### PR DESCRIPTION
I'm assuming the inconsistency between line 1 and 2/3 is what  #140 is complaining about. I added a couple strings to make it obvious they were values and not position numbers or something else.