### PR TITLE
Throw an error if PQconsumeInput fails

### DIFF
--- a/lib/DBDish/Pg/Connection.pm6
+++ b/lib/DBDish/Pg/Connection.pm6
@@ -8,7 +8,7 @@ need DBDish::TestMock;
 use DBIish::Common;
 
 has PGconn $!pg_conn handles <
-    pg-notifies pg-consume-input pg-socket pg-parameter-status
+    pg-notifies pg-socket pg-parameter-status
     pg-db pg-user pg-pass pg-host
     pg-port pg-options quote>;
 has $.AutoCommit is rw = True;
@@ -130,6 +130,14 @@ method ping {
     } else {
         False;
     }
+}
+
+method pg-consume-input(--> Bool) {
+    my $status = $!pg_conn.PQconsumeInput();
+    if (0 == $status) {
+        self!set-err(PGRES_FATAL_ERROR, $!pg_conn.PQerrorMessage);
+    }
+    return ?$status;
 }
 
 method _disconnect() {

--- a/lib/DBDish/Pg/Native.pm6
+++ b/lib/DBDish/Pg/Native.pm6
@@ -100,9 +100,6 @@ class PGconn is export is repr('CPointer') {
 
     method PQconsumeInput( --> int32) is native(LIB) { * }
 
-    method pg-consume-input(--> Bool) {
-        ?self.PQconsumeInput();
-    }
     method PQnotifies(--> Pointer) is native(LIB) { * }
     method pg-notifies(--> pg-notify) {
         class PGnotify is repr('CStruct') {


### PR DESCRIPTION
The most common error here will be a database disconnection due to network issues or pg_terminate_backend(). Without this a script waiting for a LISTEN event will never know to exit if that is the only database activity.