### PR TITLE
Change message to catch for X::LibraryMissing

### DIFF
--- a/lib/DBIish.pm6
+++ b/lib/DBIish.pm6
@@ -32,6 +32,12 @@ unit class DBIish:auth<mberends>:ver<0.5.9>;
         # I catch here to avoid the drivers the need of this logic.
         CATCH {
             when $_.message ~~ m/
+            ^ "Cannot locate symbol '" <-[ ' ]>* "' in native library "
+                    ( "'" <-[ ' ]> * "'" )
+                    / {
+                X::DBIish::LibraryMissing.new(:library($/[0]), :$driver).fail;
+            }
+            when $_.message ~~ m/
             ^ "Cannot locate native library "
             ( "'" <-[ ' ]> * "'" )
             / {


### PR DESCRIPTION
The symbol 'mysql_init' was made required in 3a4c2684 which I believe changed the error message for all platforms. This allows zef install/upgrade to work without the --force-test flag.

Tested on docker images rakudo-star:2019.03, rakudo-star:2019.07, and jjmerelo/alpine-perl6.

Solves #154