### PR TITLE
Add dollar quoting support

### DIFF
--- a/lib/DBDish/Pg.pm6
+++ b/lib/DBDish/Pg.pm6
@@ -26,14 +26,20 @@ my grammar PgTokenizer {
         ]*
         \'
     }
+    token dollar_placeholder {\$<num>}
+    token dollar_quote {
+        ( \$\$ | \$<alpha><alnum>*\$ ) .*? $0
+    }
     token placeholder { '?' }
-    token normal { <-[?"']>+ }
+    token normal { <-[?"'$]>+ }
 
     token TOP {
         ^
         (
             | <normal>
             | <placeholder>
+            | <dollar_placeholder>
+            | <dollar_quote>
             | <single_quote>
             | <double_quote>
         )*
@@ -44,6 +50,8 @@ my grammar PgTokenizer {
 my class PgTokenizer::Actions {
     has $.counter = 0;
     method single_quote($/) { make $/.Str }
+    method dollar_placeholder($/) { make $/.Str }
+    method dollar_quote($/) { make $/.Str }
     method double_quote($/) { make $/.Str }
     method placeholder($/)  { make '$' ~ ++$!counter }
     method normal($/)       { make $/.Str }

--- a/t/36-pg-native.t
+++ b/t/36-pg-native.t
@@ -2,7 +2,7 @@ v6;
 use Test;
 use DBIish;
 
-plan 17;
+plan 19;
 
 my %con-parms;
 
@@ -36,6 +36,16 @@ ok $dbh.pg-socket, "There's a socket";
 is $dbh.quote('foo'),	    "'foo'",    'Quote literal';
 is $dbh.quote('foo'):as-id, '"foo"',    'Quote Id';
 
+# Dollar Quoting. Test our tokenizer
+my $sth = $dbh.prepare(q:to/STATEMENT/);
+    SELECT $$some string value$$ AS col1, $more$another string$$ "value 'here$more$ AS col2;
+STATEMENT
+$sth.execute();
+my $row = $sth.row(:hash);
+is $row<col1>, 'some string value', 'Basic dollar quoting';
+is $row<col2>, q{another string$$ "value 'here}, 'Named dollar quoting';
+
+# Listen/Notify
 lives-ok { $dbh.do('LISTEN test') }, 'Listen to test';
 my $note = $dbh.pg-notifies;
 isa-ok $note, Any, 'No notification';


### PR DESCRIPTION
Queries like the one below would thoroughly confuse the Grammar replacing the ?'s in the query.
	SELECT $foo$' "$foo$ AS col