### PR TITLE
Remove unused function

### DIFF
--- a/lib/DBDish/Pg.pm6
+++ b/lib/DBDish/Pg.pm6
@@ -57,9 +57,6 @@ our sub pg-replace-placeholder(Str $query) is export {
         and $/.ast;
 }
 
-sub quote-and-escape($s) {
-    "'" ~ $s.trans([q{'}, q{\\]}] => [q{\\\'}, q{\\\\}]) ~ "'"
-}
 
 #------------------ methods to be called from DBIish ------------------
 


### PR DESCRIPTION
Appears to have been an early attempt at quoting. libpq's quote function will be more reliable.

No references, exports, and tests continue to pass with it removed.