### PR TITLE
Fix dollar quote with substitution variables

### DIFF
--- a/lib/DBDish/Pg.pm6
+++ b/lib/DBDish/Pg.pm6
@@ -26,7 +26,7 @@ my grammar PgTokenizer {
         ]*
         \'
     }
-    token dollar_placeholder {\$<num>}
+    token dollar_placeholder {\$<digit>+}
     token dollar_quote {
         ( \$\$ | \$<alpha><alnum>*\$ ) .*? $0
     }

--- a/t/36-pg-native.t
+++ b/t/36-pg-native.t
@@ -38,9 +38,9 @@ is $dbh.quote('foo'):as-id, '"foo"',    'Quote Id';
 
 # Dollar Quoting. Test our tokenizer
 my $sth = $dbh.prepare(q:to/STATEMENT/);
-    SELECT $$some string value$$ AS col1, $more$another string$$ "value 'here$more$ AS col2;
+    SELECT $$some string value$$ AS col1, $more$another string$$ "value 'here$more$ AS col2, $1::text AS col3;
 STATEMENT
-$sth.execute();
+$sth.execute('value');
 my $row = $sth.row(:hash);
 is $row<col1>, 'some string value', 'Basic dollar quoting';
 is $row<col2>, q{another string$$ "value 'here}, 'Named dollar quoting';


### PR DESCRIPTION
74127ba wasn't careful in handling $1, $2, etc. <num> is not proper category for selecting a digit. Also, substitution variables may be multiple digits ($10, $11, etc.)
