### PR TITLE
Additional Pg exception fields

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -202,9 +202,15 @@ and have the following additional attributes as provided by PostgreSQL
   * type ➡ PG_DIAG_SEVERITY_NONLOCALIZED
   * type-localized ➡ PG_DIAG_SEVERITY
   * sqlstate ➡ PG_DIAG_SQLSTATE
+  * statement ➡ Statement provided to prepare() or do()
+  * statement-name ➡ Statement Name provided to prepare() or created internally
   * statement-position ➡ PG_DIAG_STATEMENT_POSITION
   * internal-position ➡ PG_DIAG_INTERNAL_POSITION
   * internal-query ➡ PG_DIAG_INTERNAL_QUERY
+  * dbname ➡ Database Name from libpq pg-db()
+  * host ➡ Host from libpq pg-host()
+  * user ➡ User from libpq pg-user()
+  * port ➡ Port from libpq pg-port()
   * schema ➡ PG_DIAG_SCHEMA_NAME
   * table ➡ PG_DIAG_TABLE_NAME
   * column ➡ PG_DIAG_COLUMN_NAME

--- a/lib/DBDish/Pg/Connection.pm6
+++ b/lib/DBDish/Pg/Connection.pm6
@@ -25,10 +25,10 @@ submethod BUILD(:$!pg_conn!, :$!parent!, :$!AutoCommit) {
 
 method prepare(Str $statement, *%args) {
     state $statement_postfix = 0;
-    my $statement_name = join '_', 'pg', $*PID, $statement_postfix++;
+    my $statement-name = join '_', 'pg', $*PID, $statement_postfix++;
     my $munged = DBDish::Pg::pg-replace-placeholder($statement);
     die "Can't prepare this: '$statement'!" unless $munged;
-    my $result = $!pg_conn.PQprepare($statement_name, $munged, 0, OidArray);
+    my $result = $!pg_conn.PQprepare($statement-name, $munged, 0, OidArray);
     LEAVE { $result.PQclear if $result }
     if $result && $result.is-ok {
         self.reset-err;
@@ -38,7 +38,7 @@ method prepare(Str $statement, *%args) {
             :parent(self),
             :$statement,
             :$.RaiseError,
-            :$statement_name,
+            :$statement-name,
             |%args
         );
     } else {

--- a/t/38-pg-errors.t
+++ b/t/38-pg-errors.t
@@ -12,13 +12,13 @@ my %con-parms;
 my $dbh;
 
 try {
-  $dbh = DBIish.connect('Pg', |%con-parms);
-  CATCH {
-    when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
-        diag "$_\nCan't continue.";
+    $dbh = DBIish.connect('Pg', |%con-parms);
+    CATCH {
+        when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
+            diag "$_\nCan't continue.";
+        }
+        default { .throw; }
     }
-    default { .throw; }
-  }
 }
 without $dbh {
     skip-rest 'prerequisites failed';
@@ -29,92 +29,123 @@ ok $dbh,    'Connected';
 
 my $db-version = $dbh.server-version;
 if $db-version !~~ /^ '9.'<[3 .. 6]> | 1\d / {
-   skip-rest "Pg $db-version does not support full exception structure";
-   exit;
+    skip-rest "Pg $db-version does not support full exception structure";
+    exit;
 }
 
 # Typical error from Pg
-my $ex;
-throws-like {
-    $dbh.do(q{SELECT nocolumn FROM pg_class;});
+{
+    my $ex;
+    my $query = q{SELECT nocolumn FROM pg_class;};
+    throws-like {
+        $dbh.do($query);
 
-    CATCH {
-        default {
-            $ex = $_;
-            .throw;
+        CATCH {
+            default {
+                $ex = $_;
+                .throw;
+            }
         }
-    }
-}, X::DBDish::DBError::Pg, 'Incorrect column',
-    message => /'column "nocolumn" does not exist'/,
-    sqlstate   => '42703',
-    type    => 'ERROR',
-    type-localized => /^ .+ $/,
-    source-file   => 'parse_relation.c',
-    source-line   => / \d+ /,
-    source-function => 'errorMissingColumn';
-ok $ex.is-temporary === False, 'Incorrect column: not temporary';
+    }, X::DBDish::DBError::Pg, 'Incorrect column',
+            message => /'column "nocolumn" does not exist'/,
+            sqlstate   => '42703',
+            type    => 'ERROR',
+            type-localized => /^ .+ $/,
+            source-file   => 'parse_relation.c',
+            source-line   => / \d+ /,
+            source-function => 'errorMissingColumn',
+            statement => $query,
+            statement-name => q{},
+            dbname => %*ENV<PGDATABASE>,
+            host => / \w+ /,
+            port => / \d+ /,
+            user => %*ENV<PGUSER>;
+    ok $ex.is-temporary === False, 'Incorrect column: not temporary';
+}
 
 
 # All parameters
-throws-like {
-    $dbh.do(q:to/_QUERY_/);
-      DO LANGUAGE plpgsql $$
-        BEGIN RAISE EXCEPTION 'Field Test' USING
+{
+    my $ex;
+    my $query = q:to/_QUERY_/;
+        DO LANGUAGE plpgsql $$
+          BEGIN RAISE EXCEPTION 'Field Test' USING
                 ERRCODE = 'ERR99', DETAIL = 'Detail', HINT = 'Hint',
                 COLUMN = 'Column', CONSTRAINT = 'Constraint', DATATYPE = 'Datatype',
                 TABLE = 'Table', SCHEMA = 'Schema';
         END;$$;
     _QUERY_
 
-    # Copy needed for additional testing. throws-like cannot handle Bool type
-    CATCH {
-        default {
-            $ex = $_;
-            .throw;
+    throws-like {
+        $dbh.do($query);
+
+        # Copy needed for additional testing. throws-like cannot handle Bool type
+        CATCH {
+            default {
+                $ex = $_;
+                .throw;
+            }
         }
-    }
-}, X::DBDish::DBError::Pg, 'Raise Exception',
-    sqlstate => 'ERR99',
-    message => /'DBDish::Pg:' .* 'Error: Field Test'/,
-    native-message => 'Field Test',
-    message-detail => 'Detail',
-    message-hint => 'Hint',
-    context => 'PL/pgSQL function inline_code_block line 2 at RAISE',
-    type    => 'ERROR',
-    schema => 'Schema',
-    table => 'Table',
-    column => 'Column',
-    datatype => 'Datatype',
-    constraint => 'Constraint',
-    type-localized => /^ .+ $/,
-    source-file => 'pl_exec.c',
-    source-line => / \d+ /,
-    source-function => 'exec_stmt_raise';
-ok $ex.is-temporary === False, 'Raise Exception: not temporary';
+    }, X::DBDish::DBError::Pg, 'Raise Exception',
+            sqlstate => 'ERR99',
+            message => /'DBDish::Pg:' .* 'Error: Field Test'/,
+            native-message => 'Field Test',
+            message-detail => 'Detail',
+            message-hint => 'Hint',
+            context => 'PL/pgSQL function inline_code_block line 2 at RAISE',
+            type    => 'ERROR',
+            schema => 'Schema',
+            table => 'Table',
+            column => 'Column',
+            datatype => 'Datatype',
+            constraint => 'Constraint',
+            type-localized => /^ .+ $/,
+            source-file => 'pl_exec.c',
+            source-line => / \d+ /,
+            source-function => 'exec_stmt_raise',
+            statement => $query,
+            statement-name => q{},
+            dbname => %*ENV<PGDATABASE>,
+            host => / \w+ /,
+            port => / \d+ /,
+            user => %*ENV<PGUSER>;
+    ok $ex.is-temporary === False, 'Raise Exception: not temporary';
+}
 
 
 # Sample of a retryable error (result may be different on immediate retry).
-throws-like {
-    $dbh.do(q:to/_QUERY_/);
+{
+    my $ex;
+    my $query = q:to/_QUERY_/;
       DO LANGUAGE plpgsql $$
         BEGIN RAISE EXCEPTION 'Fake serialization failure' USING ERRCODE = '40001';
       END;$$;
     _QUERY_
 
-    CATCH {
-        default {
-            $ex = $_;
-            .throw;
+    throws-like {
+        my $sth = $dbh.prepare($query);
+        $sth.execute();
+        CATCH {
+            default {
+                $ex = $_;
+                .throw;
+            }
         }
-    }
-}, X::DBDish::DBError::Pg, 'Raise Temporary Exception',
-    message => /'Fake serialization failure'/,
-    context => 'PL/pgSQL function inline_code_block line 2 at RAISE',
-    sqlstate   => '40001',
-    type    => 'ERROR',
-    type-localized => /^ .+ $/,
-    source-file => 'pl_exec.c',
-    source-line => / \d+ /,
-    source-function => 'exec_stmt_raise';
-ok $ex.is-temporary === True, 'Raise Temporary Exception: temporary';
+    }, X::DBDish::DBError::Pg, 'Raise Temporary Exception',
+            message => /'Fake serialization failure'/,
+            context => 'PL/pgSQL function inline_code_block line 2 at RAISE',
+            sqlstate   => '40001',
+            type    => 'ERROR',
+            type-localized => /^ .+ $/,
+            source-file => 'pl_exec.c',
+            source-line => / \d+ /,
+            source-function => 'exec_stmt_raise',
+            statement => $query,
+            statement-name => / \w+ /,
+            dbname => %*ENV<PGDATABASE>,
+            host => / \w+ /,
+            port => / \d+ /,
+            user => %*ENV<PGUSER>;
+    ok $ex.is-temporary === True, 'Raise Temporary Exception: temporary';
+}
 


### PR DESCRIPTION
These additions make debugging a multi-threaded multi-connection script much more practical.

dbname, user, host, port, statement, and statement-name.

I opted to make statement and statement-name public for the handle as I couldn't think of a good reason for those to be hidden. $[!.]statement already varied by driver as SQLLite was public but MySQL, Oracle are private. IMO, they should all be public.

statement_name was renamed statement-name for consistency with other public function names.