### PR TITLE
Make $statement_postfix a local counter

### DIFF
--- a/lib/DBDish/Pg/Connection.pm6
+++ b/lib/DBDish/Pg/Connection.pm6
@@ -23,9 +23,9 @@ submethod BUILD(:$!pg_conn!, :$!parent!, :$!AutoCommit) {
        :Buf(&str-to-blob);
 }
 
+has $!statement-posfix = 0;
 method prepare(Str $statement, *%args) {
-    state $statement_postfix = 0;
-    my $statement-name = join '_', 'pg', $*PID, $statement_postfix++;
+    my $statement-name = join '_', 'pg', $*PID, $!statement-posfix++;
     my $munged = DBDish::Pg::pg-replace-placeholder($statement);
     die "Can't prepare this: '$statement'!" unless $munged;
     my $result = $!pg_conn.PQprepare($statement-name, $munged, 0, OidArray);


### PR DESCRIPTION
This server-side namespace is unique on a per-connection basis.

Using a shared variable via "state" is not thread-safe.

t/38-pg-threads.t failed with this error about 1 run in 50.

An operation first awaited:
  in block <unit> at t/38-pg-threads.t line 42

Died with the exception:
    Cannot resolve caller postfix:<++>(VMNull); the following candidates
    match the type but require mutable arguments:
        (Mu:U $a is rw)

    The following do not match for other reasons:
        (Bool:D $a is rw)
        (Bool:U $a is rw --> Bool::False)
        (Int:D $a is rw --> Int:D)
        (Mu:D $a is rw)
        (Num:D $a is rw)
        (Num:U $a is rw --> 0e0)
        (int $a is rw --> int)
        (num $a is rw --> num)
      in method prepare at /home/rbt/work/DBIish/lib/DBDish/Pg/Connection.pm6 (DBDish::Pg::Connection) line 28
      in block  at t/38-pg-threads.t line 31