### PR TITLE
Preserve original backtrace

### DIFF
--- a/lib/DBIish.pm6
+++ b/lib/DBIish.pm6
@@ -45,7 +45,7 @@ unit class DBIish:auth<mberends>:ver<0.5.9>;
                 X::DBIish::LibraryMissing.new(:library($/[0]), :$driver).fail;
             }
             default {
-                .throw;
+                .rethrow;
             };
         }
         my $d = self.install-driver( $driver, |%_ );
@@ -60,7 +60,7 @@ unit class DBIish:auth<mberends>:ver<0.5.9>;
                         X::DBIish::DriverNotFound.new(:bogus($drivername)).fail;
                     }
                     default {
-                        .throw;
+                        .rethrow;
                     }
                 }
                 my $module = "DBDish::$drivername";

--- a/lib/DBIish/CommonTesting.pm6
+++ b/lib/DBIish/CommonTesting.pm6
@@ -42,7 +42,7 @@ method run-tests {
             when X::DBIish::LibraryMissing | X::DBDish::ConnectionFailed {
                 diag "$_\nCan't continue.";
             }
-            default { .throw; }
+            default { .rethrow; }
         }
     }
     without $dbh {


### PR DESCRIPTION
There is nothing special about these .throw locations that an upstream developer would be interested in.