### PR TITLE
feat: add SQLCipher support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
 
     # Install client libraries
     - name: Install native dependencies
-      run:  sudo apt-get install -y postgresql-client libpq-dev libmysqlclient-dev sqlite3 libsqlite3-dev
+      run:  sudo apt-get install -y postgresql-client libpq-dev libmysqlclient-dev sqlite3 libsqlite3-dev sqlcipher libsqlcipher-dev
 
     # Raku image 2020.12 does not understand the fez module network. App::Prove only installs via fez
     - name: Upgrade Zef

--- a/META6.json
+++ b/META6.json
@@ -29,7 +29,7 @@
     "DBDish::SQLite::Native": "lib/DBDish/SQLite/Native.rakumod",
     "DBDish::SQLite::StatementHandle": "lib/DBDish/SQLite/StatementHandle.rakumod",
     "DBDish::SQLCipher": "lib/DBDish/SQLCipher.rakumod",
-    "DBDish::SQLCipher::Connection": "lib/DBDish/SQCipher/Connection.rakumod",
+    "DBDish::SQLCipher::Connection": "lib/DBDish/SQLCipher/Connection.rakumod",
     "DBDish::SQLCipher::Native": "lib/DBDish/SQLCipher/Native.rakumod",
     "DBDish::SQLCipher::StatementHandle": "lib/DBDish/SQLCipher/StatementHandle.rakumod",
     "DBDish::StatementHandle": "lib/DBDish/StatementHandle.rakumod",

--- a/META6.json
+++ b/META6.json
@@ -28,6 +28,10 @@
     "DBDish::SQLite::Connection": "lib/DBDish/SQLite/Connection.rakumod",
     "DBDish::SQLite::Native": "lib/DBDish/SQLite/Native.rakumod",
     "DBDish::SQLite::StatementHandle": "lib/DBDish/SQLite/StatementHandle.rakumod",
+    "DBDish::SQLCipher": "lib/DBDish/SQLCipher.rakumod",
+    "DBDish::SQLCipher::Connection": "lib/DBDish/SQCipher/Connection.rakumod",
+    "DBDish::SQLCipher::Native": "lib/DBDish/SQLCipher/Native.rakumod",
+    "DBDish::SQLCipher::StatementHandle": "lib/DBDish/SQLCipher/StatementHandle.rakumod",
     "DBDish::StatementHandle": "lib/DBDish/StatementHandle.rakumod",
     "DBDish::TestMock": "lib/DBDish/TestMock.rakumod",
     "DBDish::TestMock::Connection": "lib/DBDish/TestMock/Connection.rakumod",
@@ -56,10 +60,11 @@
     "mysql",
     "oracle",
     "postgres",
-    "sqlite"
+    "sqlite",
+    "sqlcipher"
   ],
   "test-depends": [
     "NativeCall::TypeDiag"
   ],
-  "version": "0.6.6"
+  "version": "0.6.7"
 }

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ is any of the following codes:
 
 Returns the file description number of the connection socket to the server.
 
-## SQLite
+## SQLite (and SQLCipher)
 
 Supports basic CRUD operations and prepared statements with placeholders
 
@@ -577,7 +577,8 @@ multiple processes), operations may not be able to happen immediately due to
 the database being locked. DBIish sets a default timeout of 10000 milliseconds;
 this can be changed by passing the `busy-timeout` option to `connect`.
 
-    my $dbh = DBIish.connect('SQLite', :database<thefile>, :60000busy-timeout);
+    my $dbh = DBIish.connect('SQLite',    :database<thefile>, :60000busy-timeout);
+    my $dbh = DBIish.connect('SQLCipher', :database<thefile>, :60000busy-timeout);
 
 Passing a value less than or equal to zero will disable the timeout, resulting
 in any operation that cannot take place immediately producing a database
@@ -609,6 +610,20 @@ For best performance you are recommended to use:
     if my $row = $sth.row {
         # Do something with a single record
     }
+
+### Keys - SQLCipher only
+
+To set the key for the current connection:
+
+```raku
+    $dbh.key('Tr0ub4dor&1');
+```
+
+To change the key for the current connection:
+
+```raku
+    $dbh.rekey('CorrectHorseBatteryStaple');
+```
 
 ## MySQL
 

--- a/lib/DBDish/SQLCipher.rakumod
+++ b/lib/DBDish/SQLCipher.rakumod
@@ -1,0 +1,67 @@
+use v6;
+
+need DBDish;
+
+unit class DBDish::SQLCipher:ver($?DISTRIBUTION.meta<ver>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>) does DBDish::Driver;
+use NativeLibs;
+use DBDish::SQLCipher::Native;
+need DBDish::SQLCipher::Connection;
+
+has $.library;
+has $.library-resolved = False;
+
+method connect(:database(:$dbname)! is copy, *%params) {
+    die "Cannot locate native library '" ~
+            $*VM.platform-library-name('sqlcipher'.IO, :version(v0)) ~ "'"
+    unless $!library-resolved;
+
+    my SQLCipher $p .= new;
+    if ($dbname ne ':memory:') {
+        $dbname = (
+        # Don't touch if already an IO::Path
+        $dbname ~~ IO::Path ?? $dbname !!
+                # Add the standard extension unless has one
+                ($dbname.IO.extension ?? $dbname !! $dbname ~ '.sqlcipher').IO
+        ).absolute;
+    }
+
+    my $status = sqlite3_open($dbname, $p);
+
+    # Enable extended result codes if available
+    sqlite3_extended_result_codes($p, 1);
+
+    if $status == SQLCIPHER_OK {
+        given %params<busy-timeout> // 10000 {
+            sqlite3_busy_timeout($p, .Int);
+        }
+        DBDish::SQLCipher::Connection.new(:conn($p), :parent(self), |%params);
+    }
+    else {
+        # Show the extended status code for the connection error
+        # if one is available
+        my $detailed-status = sqlite3_extended_errcode($p) // $status;
+        self!conn-error: :code($$detailed-status) :errstr(sqlite3_errmsg($p));
+    }
+}
+
+my $wks = 'sqlite3_libversion'; # A well known symbol
+method new() {
+    with (%*ENV<DBIISH_SQLCIPHER_LIB> andthen NativeLibs::Searcher.try-versions($_, $wks))
+    //   NativeLibs::Searcher.try-versions('sqlcipher', $wks, 0)
+    {
+        # Try to keep the library loaded.
+        %_<library> = NativeLibs::Loader.load($_);
+        %_<library-resolved> = True;
+    }
+    self.bless(|%_);
+}
+
+method version() {
+    $!library-resolved ?? Version.new(sqlite3_libversion) !! Nil;
+}
+
+method threadsafe(--> Bool) {
+    so sqlite3_threadsafe()
+}
+
+# vim: ft=perl6

--- a/lib/DBDish/SQLCipher/Connection.rakumod
+++ b/lib/DBDish/SQLCipher/Connection.rakumod
@@ -1,0 +1,70 @@
+use v6;
+
+need DBDish;
+
+unit class DBDish::SQLCipher::Connection does DBDish::Connection;
+need DBDish::SQLCipher::StatementHandle;
+use DBDish::SQLCipher::Native;
+
+use NativeCall;
+
+has SQLCipher $!conn;
+
+submethod BUILD(:$!conn!, :$!parent!) { }
+
+method !handle-error(Int $status) {
+    if $status == SQLCIPHER_OK {
+        self.reset-err;
+    } else {
+        self!set-err($status, sqlite3_errmsg($!conn));
+    }
+}
+
+## Provide the key for the connection.
+method key(Str $key) {
+    my $key_enc = $key.encode('utf8');
+    my $key_buf = CArray[uint8].new($key_enc);
+    my $key_ptr = nativecast(Pointer, $key_buf);
+
+    sqlite3_key($!conn, $key_ptr, $key_enc.bytes);
+};
+
+## Change the key for the connection.
+method rekey(Str $key) {
+    my $key_enc = $key.encode('utf8');
+    my $key_buf = CArray[uint8].new($key_enc);
+    my $key_ptr = nativecast(Pointer, $key_buf);
+
+    sqlite3_rekey($!conn, $key_ptr, $key_enc.bytes);
+};
+
+method prepare(Str $statement, *%args) {
+    my STMT $statement-handle .= new;
+    my $status = (sqlite3_libversion_number() >= 3003009)
+            ?? sqlite3_prepare_v2($!conn, $statement, -1, $statement-handle, Null)
+            !! sqlite3_prepare($!conn, $statement, -1, $statement-handle, Null);
+    with self!handle-error($status) {
+        DBDish::SQLCipher::StatementHandle.new(
+            :$!conn,
+            :parent(self),
+            :$statement-handle,
+            :$statement,
+            :$.RaiseError,
+            |%args
+        );
+    }
+    else {
+        .fail;
+    }
+}
+
+method ping() {
+    $!conn.defined;
+}
+
+method _disconnect() {
+    LEAVE { $!conn = Nil }
+    if $!conn and (my $status = sqlite3_close($!conn)) != SQLCIPHER_OK {
+        self!set-err($status, sqlite3_errstr($status)).fail;
+    }
+}

--- a/lib/DBDish/SQLCipher/Native.rakumod
+++ b/lib/DBDish/SQLCipher/Native.rakumod
@@ -1,0 +1,182 @@
+use v6;
+
+use NativeLibs;
+use NativeCall;
+
+unit module DBDish::SQLCipher::Native;
+
+enum SQLCIPHER is export (
+    SQLCIPHER_OK        =>    0 , #  Successful result
+    SQLCIPHER_ERROR     =>    1 , #  SQL error or missing database
+    SQLCIPHER_INTERNAL  =>    2 , #  Internal logic error in SQLCipher
+    SQLCIPHER_PERM      =>    3 , #  Access permission denied
+    SQLCIPHER_ABORT     =>    4 , #  Callback routine requested an abort
+    SQLCIPHER_BUSY      =>    5 , #  The database file is locked
+    SQLCIPHER_LOCKED    =>    6 , #  A table in the database is locked
+    SQLCIPHER_NOMEM     =>    7 , #  A malloc() failed
+    SQLCIPHER_READONLY  =>    8 , #  Attempt to write a readonly database
+    SQLCIPHER_INTERRUPT =>    9 , #  Operation terminated by sqlite3_interrupt()
+    SQLCIPHER_IOERR     =>   10 , #  Some kind of disk I/O error occurred
+    SQLCIPHER_CORRUPT   =>   11 , #  The database disk image is malformed
+    SQLCIPHER_NOTFOUND  =>   12 , #  Unknown opcode in sqlite3_file_control()
+    SQLCIPHER_FULL      =>   13 , #  Insertion failed because database is full
+    SQLCIPHER_CANTOPEN  =>   14 , #  Unable to open the database file
+    SQLCIPHER_PROTOCOL  =>   15 , #  Database lock protocol error
+    SQLCIPHER_EMPTY     =>   16 , #  Database is empty
+    SQLCIPHER_SCHEMA    =>   17 , #  The database schema changed
+    SQLCIPHER_TOOBIG    =>   18 , #  String or BLOB exceeds size limit
+    SQLCIPHER_CONSTRAINT=>   19 , #  Abort due to constraint violation
+    SQLCIPHER_MISMATCH  =>   20 , #  Data type mismatch
+    SQLCIPHER_MISUSE    =>   21 , #  Library used incorrectly
+    SQLCIPHER_NOLFS     =>   22 , #  Uses OS features not supported on host
+    SQLCIPHER_AUTH      =>   23 , #  Authorization denied
+    SQLCIPHER_FORMAT    =>   24 , #  Auxiliary database format error
+    SQLCIPHER_RANGE     =>   25 , #  2nd parameter to sqlite3_bind out of range
+    SQLCIPHER_NOTADB    =>   26 , #  File opened that is not a database file
+    SQLCIPHER_ROW       =>   100, #  sqlite3_step() has another row ready
+    SQLCIPHER_DONE      =>   101, #  sqlite3_step() has finished executing
+);
+
+
+enum SQLCIPHER_TYPE is export (
+    SQLCIPHER_INTEGER => 1,
+    SQLCIPHER_FLOAT   => 2,
+    SQLCIPHER_TEXT    => 3,
+    SQLCIPHER_BLOB    => 4,
+    SQLCIPHER_NULL    => 5
+);
+
+constant LIB = 'sqlcipher';
+
+constant Null is export = Pointer;
+class SQLCipher is export is repr('CPointer') { };
+class STMT is export is repr('CPointer') { };
+# Can't use the following 'cus produces
+#  "Missing serialize REPR function for REPR CPointer"
+# at install time.
+#constant SQLCIPHER_TRANSIENT = Pointer.new(-1);
+
+sub sqlite3_threadsafe()
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
+
+sub sqlite3_errmsg(SQLCipher $handle)
+    returns Str
+    is native(LIB)
+    is export
+    { ... }
+
+sub sqlite3_extended_result_codes(SQLCipher $handle, int32)
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
+
+sub sqlite3_extended_errcode(SQLCipher $handle)
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
+
+sub sqlite3_open(Str $filename, SQLCipher $handle is rw)
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
+
+sub sqlite3_close(SQLCipher)
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
+
+sub sqlite3_busy_timeout(SQLCipher, int32)
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
+
+sub sqlite3_prepare_v2 (
+        SQLCipher,
+        Str  $statement is encoded('utf8'),
+        int32 $statement-length,
+        STMT $statement-handle is rw,
+        Pointer
+    )
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
+
+sub sqlite3_prepare (
+        SQLCipher,
+        Str $statement is encoded('utf8'),
+        int32 $statement-length,
+        STMT $statement-handle is rw,
+        Pointer
+    )
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
+
+sub sqlite3_step(STMT $statement-handle)
+    returns int32
+    is native(LIB)
+    is export
+    { ... }
+
+sub sqlite3_key(SQLCipher, Pointer $key is encoded('utf8'), int32 $keylen)
+    returns int32 is native(LIB) is export { ... };
+sub sqlite3_key_v2(SQLCipher, Str $zDbName is encoded('utf8'), Pointer $key, int32 $keylen)
+    returns int32 is native(LIB) is export { ... };
+sub sqlite3_rekey(SQLCipher, Pointer $key is encoded('utf8'), int32 $keylen)
+    returns int32 is native(LIB) is export { ... };
+sub sqlite3_rekey_v2(SQLCipher, Str $zDbName is encoded('utf8'), Pointer $key, int32 $keylen)
+    returns int32 is native(LIB) is export { ... };
+
+sub sqlite3_libversion_number() returns int32 is native(LIB) is export { ... };
+sub sqlite3_libversion(--> Str) is export is native(LIB) { * }
+sub sqlite3_errstr(int32) returns Str is native(LIB) is export { ... };
+sub sqlite3_bind_blob(STMT, int32, Blob, int32, Pointer) returns int32 is native(LIB) is export { ... };
+sub sqlite3_bind_double(STMT, int32, num64) returns int32 is native(LIB) is export { ... };
+sub sqlite3_bind_int64(STMT, int32, int64) returns int32 is native(LIB) is export { ... };
+sub sqlite3_bind_null(STMT, int32) returns int32 is native(LIB) is export { ... };
+sub sqlite3_bind_text(STMT, int32, Str is encoded('utf8'), int32, Pointer) returns int32 is native(LIB) is export { ... };
+
+sub sqlite3_changes(SQLCipher) returns int32 is native(LIB) is export { ... };
+sub sqlite3_bind_parameter_count(STMT --> int32) is native(LIB) is export { ... };
+
+proto sub sqlite3_bind(STMT, $, $) {*}
+multi sub sqlite3_bind(STMT $stmt, Int $n, Blob:D $b)  is export {
+    sqlite3_bind_blob($stmt, $n, $b, $b.bytes, Pointer.new(-1))
+}
+multi sub sqlite3_bind(STMT $stmt, Int $n, Real:D $d) is export {
+    sqlite3_bind_double($stmt, $n, $d.Num)
+}
+multi sub sqlite3_bind(STMT $stmt, Int $n, Int:D $i)  is export {
+    sqlite3_bind_int64($stmt, $n, $i)
+}
+multi sub sqlite3_bind(STMT $stmt, Int $n, Any:U)     is export {
+    sqlite3_bind_null($stmt, $n)
+}
+multi sub sqlite3_bind(STMT $stmt, Int $n, Str:D $d)  is export {
+    sqlite3_bind_text($stmt, $n, $d, -1, Pointer.new(-1))
+}
+
+sub sqlite3_reset(STMT) returns int32 is native(LIB) is export  { ... }
+sub sqlite3_clear_bindings(STMT) returns int32 is native(LIB) is export { ... }
+
+sub sqlite3_column_text(STMT, int32) returns Str is native(LIB) is export  { ... }
+sub sqlite3_column_double(STMT, int32) returns num64 is native(LIB) is export { ... }
+sub sqlite3_column_int64(STMT, int32) returns int64 is native(LIB) is export { ... }
+sub sqlite3_column_blob(STMT, int32) returns Pointer is native(LIB) is export { ... }
+sub sqlite3_column_bytes(STMT, int32) returns int32 is native(LIB) is export { ... }
+
+sub sqlite3_finalize(STMT) returns int32 is native(LIB) is export { ... }
+sub sqlite3_column_count(STMT) returns int32 is native(LIB) is export { ... }
+sub sqlite3_column_name(STMT, int32) returns Str is native(LIB) is export { ... }
+sub sqlite3_column_type(STMT, int32) returns int32 is native(LIB) is export { ... }
+

--- a/lib/DBDish/SQLCipher/StatementHandle.rakumod
+++ b/lib/DBDish/SQLCipher/StatementHandle.rakumod
@@ -1,0 +1,115 @@
+use v6;
+need DBDish;
+
+unit class DBDish::SQLCipher::StatementHandle does DBDish::StatementHandle;
+use DBDish::SQLCipher::Native;
+use NativeHelpers::Blob;
+use NativeCall;
+
+has SQLCipher $!conn;
+has $.statement;
+has $!statement-handle;
+has $!param-count;
+has Int $!row-status;
+has $!field-count;
+has Bool $!rows-is-accurate = False;
+
+method !handle-error(Int $status) {
+    unless $status == SQLCIPHER_OK {
+        self!set-err($status, sqlite3_errmsg($!conn));
+    }
+}
+
+submethod BUILD(:$!conn!, :$!parent!, :$!statement-handle!,
+    :$!statement
+) {
+    $!param-count = sqlite3_bind_parameter_count($!statement-handle);
+    $!field-count = sqlite3_column_count($!statement-handle);
+    for ^$!field-count {
+        @!column-name.push: sqlite3_column_name($!statement-handle, $_);
+        @!column-type.push: Any;
+    }
+}
+
+method execute(*@params is raw --> DBDish::StatementHandle) {
+    self!enter-execute(@params.elems, $!param-count);
+
+    my int $num-params = @params.elems;
+    loop (my int $idx = 0; $idx < $num-params; $idx++) {
+        self!handle-error(sqlite3_bind($!statement-handle, $idx + 1, @params[$idx]));
+    }
+    $!row-status = sqlite3_step($!statement-handle);
+    if $!row-status == SQLCIPHER_ROW | SQLCIPHER_DONE {
+        my $rows = 0;
+        if $!field-count == 0 { # Non-SELECT
+            $!rows-is-accurate = True;
+            $rows = sqlite3_changes($!conn);
+        }
+
+        self.reset-err;
+        self!done-execute($rows, $!field-count);
+    } else {
+        self!set-err($!row-status, sqlite3_errmsg($!conn));
+    }
+}
+
+# Override DBDish::StatementHandle to throw this error
+method rows() {
+    # Warn if rows is inaccurate. Message may be suppressed with a CONTROL block.
+    if (not $!rows-is-accurate) {
+        warn "SQLCipher rows() result may not be accurate. See SQLite rows section of README for details."
+    }
+
+    self._rows();
+}
+
+method _row() {
+    my $list = ();
+    if $!row-status == SQLCIPHER_ROW {
+        $list = do for ^$!field-count -> $col {
+            my $value = do {
+                given sqlite3_column_type($!statement-handle, $col) {
+                    when SQLCIPHER_INTEGER { sqlite3_column_int64($!statement-handle, $col) }
+                    when SQLCIPHER_FLOAT {
+                        sqlite3_column_double($!statement-handle, $col) }
+                    when SQLCIPHER_BLOB {
+                        my \p = sqlite3_column_blob($!statement-handle, $col);
+                        my $elems = sqlite3_column_bytes($!statement-handle, $col);
+                        blob-from-pointer(p, :$elems);
+                    }
+                    when SQLCIPHER_NULL { @!column-type[$col] }
+                    default { sqlite3_column_text($!statement-handle, $col) }
+                }
+            }
+            my $ct = @!column-type[$col];
+            ($ct === Any || $value ~~ $ct) ?? $value !! $value.$ct;
+        }
+        $!affected-rows++;
+        self.reset-err;
+        if ($!row-status = sqlite3_step($!statement-handle)) == SQLCIPHER_DONE {
+            # Only after retrieving the final record is the rows value considered accurate.
+            $!rows-is-accurate = True;
+            self.finish;
+        }
+    } elsif $!row-status == SQLCIPHER_DONE {
+        # An empty result is considered accurate immediately.
+        $!rows-is-accurate = True;
+    }
+    $list;
+}
+
+method _free {
+    with $!statement-handle {
+        sqlite3_finalize($_);
+        $_ = Nil;
+        $!row-status = Int;
+    }
+}
+
+method finish {
+    with $!statement-handle {
+        sqlite3_reset($_);
+        sqlite3_clear_bindings($_);
+    }
+    $!Finished = True;
+}

--- a/lib/DBIish/CommonTesting.rakumod
+++ b/lib/DBIish/CommonTesting.rakumod
@@ -213,7 +213,7 @@ method run-tests {
         [ 'TAFM', 'Mild fish taco', 1, 4.85, 4.85 ]
     );
 
-    if $.dbd eq 'SQLite' | 'SQLCipher' { # Munge types
+    if $.dbd ~~ any <SQLite SQLCipher> { # Munge types
         $sth.column-types[$_] = [Str, Str, Int, Rat, Rat][$_] for ^5;
     }
 
@@ -240,7 +240,7 @@ method run-tests {
     is @columns.elems, 5, "column-type returns 5 fields in a row";
     ok @columns eqv [ Str, Str, Int, Rat, Rat ], 'column-types matches test data';
 
-    if $.dbd eq 'SQLite' | 'SQLCipher' { # Munge types
+    if $.dbd ~~ any <SQLite SQLCipher> { # Munge types
         $sth.column-types[$_] = [Str, Str, Int, Rat, Rat][$_] for ^5;
     }
 

--- a/lib/DBIish/CommonTesting.rakumod
+++ b/lib/DBIish/CommonTesting.rakumod
@@ -199,8 +199,8 @@ method run-tests {
 
     # TODO Different drivers returns different values, should implement the
     # capabilities announce.
-    todo 'Will probably fails for the lack of proper capabilities announce'
-    if $.dbd eq 'SQLite' | 'Oracle';
+    todo 'Will probably fail due to lack of capabilities announce'
+        if $.dbd ~~ any <SQLite Oracle SQLCipher>;
     is $rc, 6,          'In an ideal world should returns rows available';
 
     #row and allrows return typed value, when possible
@@ -213,7 +213,7 @@ method run-tests {
         [ 'TAFM', 'Mild fish taco', 1, 4.85, 4.85 ]
     );
 
-    if $.dbd eq 'SQLite' { # Munge types
+    if $.dbd eq 'SQLite' | 'SQLCipher' { # Munge types
         $sth.column-types[$_] = [Str, Str, Int, Rat, Rat][$_] for ^5;
     }
 
@@ -240,7 +240,7 @@ method run-tests {
     is @columns.elems, 5, "column-type returns 5 fields in a row";
     ok @columns eqv [ Str, Str, Int, Rat, Rat ], 'column-types matches test data';
 
-    if $.dbd eq 'SQLite' { # Munge types
+    if $.dbd eq 'SQLite' | 'SQLCipher' { # Munge types
         $sth.column-types[$_] = [Str, Str, Int, Rat, Rat][$_] for ^5;
     }
 

--- a/t/70-sqlcipher-memory.rakutest
+++ b/t/70-sqlcipher-memory.rakutest
@@ -1,0 +1,11 @@
+# DBIish/t/40-SQLite-common.t
+use v6;
+need DBIish::CommonTesting;
+
+DBIish::CommonTesting.new(
+    dbd => 'SQLCipher',
+    opts => {
+        :database(':memory:')
+    },
+    typed-nulls => False # TODO Is the driver who needs to provide the info
+).run-tests;

--- a/t/71-sqlcipher-common.rakutest
+++ b/t/71-sqlcipher-common.rakutest
@@ -1,0 +1,13 @@
+# DBIish/t/40-SQLite-common.t
+use v6;
+need DBIish::CommonTesting;
+
+my $TDB = IO::Path.new('dbdish-sqlcipher-test.sqlite3');
+DBIish::CommonTesting.new(
+    dbd => 'SQLCipher',
+    opts => {
+        :database($TDB)
+    },
+    typed-nulls => False # TODO Is the driver who needs to provide the info
+).run-tests;
+$TDB.unlink;

--- a/t/72-sqlcipher-blob.rakutest
+++ b/t/72-sqlcipher-blob.rakutest
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+use DBIish::CommonTesting;
+
+plan 20;
+
+my $TDB = IO::Path.new('dbdishtest.sqlcipher');
+my $KEY = 'CorrectHorseBatteryStaple';
+my $NEW_KEY = 'SomeOtherKeyWithMoreWords';
+my %con-parms;
+%con-parms<database> = ~$TDB;
+my $dbh = DBIish::CommonTesting.connect-or-skip('SQLCipher', |%con-parms);
+
+ok $dbh,    'Connected';
+lives-ok { $dbh.key($KEY); }, 'key lives';
+lives-ok { $dbh.execute('DROP TABLE IF EXISTS test_blob') }, 'Clean';
+lives-ok {
+    $dbh.execute(q|
+    CREATE TABLE test_blob (
+	id INT NOT NULL DEFAULT 0, 
+	name bytea)|)
+}, 'Table created';
+my $blob = Buf.new(^256);
+my $query = 'INSERT INTO test_blob VALUES(?, ?)';
+ok (my $sth = $dbh.prepare($query)),	 "Prepared '$query'";
+ok $sth.execute(1, $blob),		 'Executed with buf';
+ok $sth.execute(2, Buf),		 'Executed without buf';
+ok $sth = $dbh.prepare('SELECT name FROM test_blob WHERE id = ?'), 'SELECT prepared';
+$sth.column-types[0] = Buf;
+ok $sth.execute(1), 'Executed for 1';
+ok (my @res = $sth.row), 'Get a row';
+is @res.elems,  1,	 'One field';
+ok (my $data = @res[0]), 'With data at 0';
+ok $data ~~ Buf,         'Data is-a Buf';
+is $data, $blob,         'Data in Buf match with original';
+ok $sth.execute(2),      'Executed for 2';
+ok (@res = $sth.row),	 'Get a row';
+is @res.elems,  1,	 'One field';
+$data = @res[0];
+ok $data ~~ Buf,         'Data is-a Buf';
+ok not $data.defined,    'But is NULL';
+lives-ok { $dbh.rekey($NEW_KEY); }, 'rekey lives';
+$dbh.execute('DROP TABLE IF EXISTS test_blob');
+$dbh.dispose;
+$TDB.unlink;

--- a/t/73-sqlcipher-errors.rakutest
+++ b/t/73-sqlcipher-errors.rakutest
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+plan 18;
+use DBIish;
+
+# Test some errors
+ok not DBIish.err,  "At start DBIish.err is 0";
+throws-like {
+    DBIish.connect('SQLCipher');
+}, X::AdHoc, 'Need database';
+
+my $dbfile = 'exec-error';
+unless DBIish.install-driver('SQLCipher').version {
+    skip-rest 'No SQLCipher library installed';
+    exit;
+}
+
+throws-like {
+    DBIish.connect('SQLCipher', :database</no-such/database>);
+}, X::DBDish::ConnectionFailed, "Die on invalid database";
+ok so DBIish.err,     "Error registered";
+
+ok (my $dbh =  DBIish.connect('SQLCipher', dbname => $dbfile)), 'Created';
+lives-ok { $dbh.key('CorrectHorseBatteryStaple'); }
+ok not $dbh.err,    'Without errors en $dbh';
+ok not DBIish.err,  'Error cleared in DBIish';
+
+lives-ok {
+    $dbh.execute('DROP TABLE IF EXISTS with_unique');
+    $dbh.execute('CREATE TABLE with_unique(a integer not null, b integer not null, UNIQUE(a, b))');
+}, 'Can create table';
+
+my $insert = $dbh.prepare('INSERT INTO with_unique(a, b) VALUES(?, ?)');
+
+lives-ok { $insert.execute(1, 1) }, 'Can insert tuple the first time';
+throws-like {
+    $insert.execute(1, 1);
+}, X::DBDish::DBError,  'Cannot insert tuple the second time';
+
+ok so $insert.err,      'Has error at $sth level';
+ok (my $e = $insert.errstr),    'Error preserved';
+ok so $dbh.err,         'Has error at $dbh level';
+ok so $dbh.drv.err,     'Has error at $drv level';
+ok so DBIish.err,     'Has error at DBIish level';
+is DBIish.errstr, $e,      'Propagated to DBIish';
+like $e, rx:i/UNIQUE/;
+$dbh.dispose; # Close the connection
+
+END { try unlink "$dbfile.sqlcipher" };

--- a/t/74-key-issues.rakutest
+++ b/t/74-key-issues.rakutest
@@ -1,0 +1,100 @@
+use v6;
+use Test;
+use DBIish::CommonTesting;
+
+plan 12;
+
+my $TDB = IO::Path.new('dbdishkeytest.sqlcipher');
+my $KEY = 'CorrectHorseBatteryStaple';
+my $NEW_KEY = 'SomeOtherKeyWithMoreWords';
+my %con-parms;
+%con-parms<database> = ~$TDB;
+
+# ---------- SETUP -------------------------------------------------------------------
+my $dbh = DBIish::CommonTesting.connect-or-skip('SQLCipher', |%con-parms);
+ok $dbh,    'Connected';
+
+# SET THE KEY TO $KEY
+$dbh.key($KEY);
+
+# CREATE AND POPULATE A TABLE
+lives-ok {
+    $dbh.execute(q|
+    CREATE TABLE test_blob (
+	id INT NOT NULL DEFAULT 0, 
+	name bytea)|)
+}, 'Table created';
+my $blob = Buf.new(^256);
+my $query = 'INSERT INTO test_blob VALUES(?, ?)';
+
+$dbh.dispose;
+
+# ---------- NO KEY -------------------------------------------------------------------
+my $dbh2 = DBIish::CommonTesting.connect-or-skip('SQLCipher', |%con-parms);
+
+my $sth2;
+throws-like {
+    $sth2 = $dbh2.prepare('SELECT name FROM test_blob WHERE id = ?');
+}, X::DBDish::DBError, 'No key, can\'t prepare.';
+
+$dbh2.dispose;
+
+# ---------- WRONG KEY -------------------------------------------------------------------
+my $dbh3 = DBIish::CommonTesting.connect-or-skip('SQLCipher', |%con-parms);
+
+lives-ok { 
+    $dbh3.key('WRONG KEY'); 
+}, 'Does not fail immediately on setting wrong key.';
+
+my $sth3;
+throws-like {
+    $sth3 = $dbh3.prepare('SELECT name FROM test_blob WHERE id = ?');
+}, X::DBDish::DBError, 'Wrong key, can\'t prepare.';
+
+$dbh3.dispose;
+
+# ---------- RIGHT KEY -------------------------------------------------------------------
+my $dbh4 = DBIish::CommonTesting.connect-or-skip('SQLCipher', |%con-parms);
+
+lives-ok { 
+    $dbh4.key($KEY); 
+}, 'Setting right key works.';
+
+my $sth4;
+ok $sth4 = $dbh4.prepare('SELECT name FROM test_blob WHERE id = ?'), 
+    'Can prepare a statement with right key';
+
+# CHANGE KEY
+lives-ok {
+    $dbh4.rekey($NEW_KEY);
+}, 'Change key does not die';
+
+$dbh4.dispose;
+
+# ---------- OLD KEY -------------------------------------------------------------------
+my $dbh5 = DBIish::CommonTesting.connect-or-skip('SQLCipher', |%con-parms);
+
+lives-ok { 
+    $dbh5.key($KEY); 
+}, 'Does not fail immediately on setting wrong key.';
+
+my $sth5;
+throws-like {
+    $sth5 = $dbh5.prepare('SELECT name FROM test_blob WHERE id = ?');
+}, X::DBDish::DBError, 'Old key is now wrong, can\'t prepare.';
+
+$dbh5.dispose;
+
+# ---------- NEW KEY -------------------------------------------------------------------
+my $dbh6 = DBIish::CommonTesting.connect-or-skip('SQLCipher', |%con-parms);
+
+lives-ok { 
+    $dbh6.key($NEW_KEY); 
+}, 'Setting right key works.';
+
+my $sth6;
+ok $sth6 = $dbh6.prepare('SELECT name FROM test_blob WHERE id = ?'), 
+    'Can prepare a statement with the new key';
+
+$dbh6.dispose;
+$TDB.unlink;


### PR DESCRIPTION
This PR adds support for [SQLCipher](https://www.zetetic.net/sqlcipher/).

The db handle has `key` and `rekey` methods which can set & change the AES256 encryption key (see the docs for [key](https://www.zetetic.net/sqlcipher/sqlcipher-api/#sqlite3_key) and [rekey](https://www.zetetic.net/sqlcipher/sqlcipher-api/#sqlite3_rekey)). The tests are a direct copy of the SQLite tests with key tests added, so all the functionality that's tested in sqlite is tested here too.

I aimed for consistency with the existing code style as much as possible.